### PR TITLE
(WIP) Denser attractors mapped by Recurrences

### DIFF
--- a/src/mapping/attractor_mapping.jl
+++ b/src/mapping/attractor_mapping.jl
@@ -3,7 +3,6 @@
 
 export AttractorMapper,
     AttractorsViaRecurrences,
-    AttractorsViaRecurrencesSparse,
     AttractorsViaProximity,
     AttractorsViaFeaturizing,
     ClusteringConfig,

--- a/src/mapping/attractor_mapping_recurrences.jl
+++ b/src/mapping/attractor_mapping_recurrences.jl
@@ -408,7 +408,7 @@ function _identify_basin_of_cell!(
 
     if bsn_nfo.state == :att_found
         if ic_label == 0 || ic_label == bsn_nfo.visited_cell
-            # Maybe chaotic attractor, perodic or long recursion.
+            # Maybe chaotic attractor, periodic or long recursion.
             # label this box as part of an attractor
             bsn_nfo.basins[n] = bsn_nfo.current_att_label
             bsn_nfo.consecutive_match = 1
@@ -417,6 +417,7 @@ function _identify_basin_of_cell!(
             # We make sure we hit the attractor another mx_chk_loc_att consecutive times
             # just to be sure that we have the complete attractor
             bsn_nfo.consecutive_match += 1
+            store_attractor!(bsn_nfo, u_full_state, show_progress)
         elseif iseven(ic_label) && bsn_nfo.consecutive_match >= mx_chk_loc_att
             # We have checked the presence of an attractor: tidy up everything
             # and get a new cell

--- a/src/mapping/attractor_mapping_recurrences.jl
+++ b/src/mapping/attractor_mapping_recurrences.jl
@@ -31,6 +31,9 @@ dimensional subspace.
 * `diffeq = NamedTuple()`: Keyword arguments propagated to [`integrator`](@ref). Only
   valid for `ContinuousDynamicalSystem`. It is recommended to choose high accuracy
   solvers for this application, e.g. `diffeq = (alg=Vern9(), reltol=1e-9, abstol=1e-9)`.
+* `stop_at_dt = true`: control whether the integrator advances exactly `Δt` time points
+  with each step or not. Being true typically slows down the algorithm but leads to denser
+  trajectories. This might be preferrable for some attractors such as limit cycles.
 * `mx_chk_att = 2`: A parameter that sets the maximum checks of consecutives hits of
   an attractor before deciding the basin of the initial condition.
 * `mx_chk_hit_bas = 10`: Maximum check of consecutive visits of the same basin of
@@ -93,9 +96,10 @@ end
 
 
 function AttractorsViaRecurrences(ds::GeneralizedDynamicalSystem, grid;
-        Δt = nothing, diffeq = NamedTuple(), sparse = true, unsafe = false, kwargs...
+        Δt = nothing, diffeq = NamedTuple(), sparse = true, unsafe = false,
+        stop_at_dt=true, kwargs...
     )
-    bsn_nfo, integ = basininfo_and_integ(ds, grid, Δt, diffeq, sparse, unsafe)
+    bsn_nfo, integ = basininfo_and_integ(ds, grid, Δt, diffeq, sparse, unsafe, stop_at_dt)
     return AttractorsViaRecurrences(integ, bsn_nfo, grid, kwargs)
 end
 
@@ -188,7 +192,7 @@ mutable struct BasinsInfo{B, IF, D, T, Q, A <: AbstractArray{Int32, B}}
 end
 
 function basininfo_and_integ(
-        ds::GeneralizedDynamicalSystem, grid, Δt, diffeq, sparse, unsafe
+        ds::GeneralizedDynamicalSystem, grid, Δt, diffeq, sparse, unsafe, stop_at_dt
     )
     integ = integrator(ds; diffeq)
     isdiscrete = isdiscretetime(integ)
@@ -196,7 +200,7 @@ function basininfo_and_integ(
     iter_f! = if (isdiscrete && Δt == 1)
         (integ) -> step!(integ)
     else
-        (integ) -> step!(integ, Δt)
+        (integ) -> step!(integ, Δt, stop_at_dt)
     end
     bsn_nfo = init_bsn_nfo(grid, integ, iter_f!, sparse, unsafe)
     return bsn_nfo, integ

--- a/src/mapping/attractor_mapping_recurrences.jl
+++ b/src/mapping/attractor_mapping_recurrences.jl
@@ -7,8 +7,6 @@ include("sparse_arrays.jl")
 Map initial conditions to attractors by identifying attractors on the fly based on
 recurrences in the state space, as outlined by Datseris & Wagemakers[^Datseris2022].
 Works for any case encapsulated by [`GeneralizedDynamicalSystem`](@ref).
-The version [`AttractorsViaRecurrencesSparse`](@ref) should practically always be
-preferred over this one.
 
 `grid` is a tuple of ranges partitioning the state space so that a finite state
 machine can operate on top of it. For example
@@ -18,6 +16,12 @@ system. The grid has to be the same dimensionality as the state space, use a
 dimensional subspace.
 
 ## Keyword Arguments
+* `sparse = true`: control the interval representation of the state space grid. If true,
+   uses a sparse array, whose memory usage is in general more efficient than a regular
+   array obtained with `sparse=false`. In practice, the sparse representation should
+   always be preferred when searching for [`basins_fractions`](@ref). Only for very low
+   dimensional systems and for computing the full [`basins_of_attraction`](@ref) the
+   non-sparse version should be used.
 * `Δt`: Approximate time step of the integrator, which is `1` for discrete systems.
   For continuous systems, an automatic value is calculated using
   [`automatic_Δt_basins`](@ref).
@@ -89,27 +93,9 @@ end
 
 
 function AttractorsViaRecurrences(ds::GeneralizedDynamicalSystem, grid;
-        Δt = nothing, diffeq = NamedTuple(), sparse = false, unsafe = false, kwargs...
+        Δt = nothing, diffeq = NamedTuple(), sparse = true, unsafe = false, kwargs...
     )
     bsn_nfo, integ = basininfo_and_integ(ds, grid, Δt, diffeq, sparse, unsafe)
-    return AttractorsViaRecurrences(integ, bsn_nfo, grid, kwargs)
-end
-
-"""
-    AttractorsViaRecurrencesSparse(ds::GeneralizedDynamicalSystem, grid::Tuple; kwargs...)
-This version is practically identical to [`AttractorsViaRecurrences`](@ref),
-with the difference that the internal representation of the grid uses a sparse array.
-In practice, it should always be preferred when searching for [`basins_fractions`](@ref).
-Only for very low dimensional systems and for computing the full
-[`basins_of_attraction`](@ref) the non-sparse version should be used.
-
-See the docstring of [`AttractorsViaRecurrences`](@ref) for possible keywords
-and details on the algorithm.
-"""
-function AttractorsViaRecurrencesSparse(ds::GeneralizedDynamicalSystem, grid;
-        Δt = nothing, diffeq = NamedTuple(), unsafe=false, kwargs...
-    )
-    bsn_nfo, integ = basininfo_and_integ(ds, grid, Δt, diffeq, true, unsafe)
     return AttractorsViaRecurrences(integ, bsn_nfo, grid, kwargs)
 end
 

--- a/test/continuation/recurrences_continuation_tests.jl
+++ b/test/continuation/recurrences_continuation_tests.jl
@@ -13,7 +13,7 @@ using Random
     pidx = :γs
     for (j, ps) in enumerate((psorig, reverse(psorig)))
         # test that both finding and removing attractor works
-        mapper = AttractorsViaRecurrences(ds, (xg, yg); Δt = 1.0)
+        mapper = AttractorsViaRecurrences(ds, (xg, yg); sparse=false, Δt = 1.0)
         sampler, = statespace_sampler(; min_bounds = [-3,-3], max_bounds = [3,3])
 
         continuation = RecurrencesSeedingContinuation(mapper; threshold = Inf)
@@ -113,7 +113,7 @@ end
     # really small threshold like 0.2 we still get a "single" attractor
     # throughout the range. Now we get one with period 14, a chaotic,
     # and one with period 7 that spans the second half of the parameter range
-    mapper = AttractorsViaRecurrences(ds, (xg, yg),
+    mapper = AttractorsViaRecurrences(ds, (xg, yg); sparse=false,
         mx_chk_fnd_att = 3000,
         mx_chk_loc_att = 3000
     )
@@ -185,7 +185,7 @@ end
     sampler, = statespace_sampler(Random.MersenneTwister(1234);
         min_bounds = [-2,-2], max_bounds = [2,2]
     )
-    mapper = AttractorsViaRecurrences(ds, (xg, yg))
+    mapper = AttractorsViaRecurrences(ds, (xg, yg); sparse=false)
     continuation = RecurrencesSeedingContinuation(mapper)
     fractions_curves, attractors_info = basins_fractions_continuation(
         continuation, ps, pidx, sampler;

--- a/test/mapping/attractor_mapping_tests.jl
+++ b/test/mapping/attractor_mapping_tests.jl
@@ -74,12 +74,12 @@ function test_basins(ds, u0s, grid, expected_fs_raw, featurizer;
         test_basins_fractions(mapper; known = true, err = aerr)
     end
 
-    @testset "Recurrences" begin
-        mapper = AttractorsViaRecurrences(ds, grid; diffeq, show_progress = false, kwargs...)
+    @testset "Recurrences Non-Sparse" begin
+        mapper = AttractorsViaRecurrences(ds, grid; sparse=false, diffeq, show_progress = false, kwargs...)
         test_basins_fractions(mapper; err = rerr)
     end
     @testset "Recurrences Sparse" begin
-        mapper = AttractorsViaRecurrencesSparse(ds, grid; diffeq, show_progress = false, kwargs...)
+        mapper = AttractorsViaRecurrences(ds, grid; sparse=true, diffeq, show_progress = false, kwargs...)
         test_basins_fractions(mapper; err = rerr)
     end
     @testset "Featurizing, unsupervised" begin


### PR DESCRIPTION
Two additions to make the attractors found by Recurrences denser:
1. add `stop_at_dt` in step! 
2. store the attractors every time a cell if revisited, so that the number of points in attractors will be at least `mx_chk_loc_att` 


This is one fix for the problem of the algorithm finding two limit cycles when it should find only one. We found this occurs when the limit cycles stored in memory are "sparse", in the sense that there are large gaps between their points. The change No 2. does not by itself fix the problem. Something happens sometimes when `stop_at_dt=false` that makes the integrator only reach the same set of points belonging to the limit cycle and it then does not fill it densely. It seems from some quick tests that this is not only when `\Delta t` is commensurate with the cycle's period. There may be something with how it is stepping, but I don't understand that.

One point to verify is if these changes slow the code down significantly. And whether it is good to store so many points in the attractors. At the very least we should probably improve the documentation on this keyword, as it seems both George and I were confused about it (though the code itself is quite clearly written).