### PR TITLE
Fix rogue rng in continuation algorithm

### DIFF
--- a/src/continuation/continuation_recurrences.jl
+++ b/src/continuation/continuation_recurrences.jl
@@ -1,5 +1,6 @@
 export RecurrencesSeedingContinuation
 import ProgressMeter
+using Random: MersenneTwister
 
 # The recurrences based method is rather flexible because it works
 # in two independent steps: it first finds attractors and then matches them.
@@ -39,11 +40,12 @@ function RecurrencesSeedingContinuation(
     )
 end
 
-function _default_seeding_process(attractor::AbstractDataset)
+function _default_seeding_process(attractor::AbstractDataset; rng = MersenneTwister(1))
     max_possible_seeds = 10
     seeds = round(Int, log(10, length(attractor)))
     seeds = clamp(seeds, 1, max_possible_seeds)
-    return (rand(attractor.data) for _ in 1:seeds)
+    return (rand(rng, attractor.data) for _ in 1:seeds)
+    # return (rand(attractor.data) for _ in 1:seeds)
 end
 
 function basins_fractions_continuation(

--- a/src/continuation/continuation_recurrences.jl
+++ b/src/continuation/continuation_recurrences.jl
@@ -45,7 +45,6 @@ function _default_seeding_process(attractor::AbstractDataset; rng = MersenneTwis
     seeds = round(Int, log(10, length(attractor)))
     seeds = clamp(seeds, 1, max_possible_seeds)
     return (rand(rng, attractor.data) for _ in 1:seeds)
-    # return (rand(attractor.data) for _ in 1:seeds)
 end
 
 function basins_fractions_continuation(


### PR DESCRIPTION
I was working on the recurrences continuation algorithm for a system that seems to have riddled basins, and I noticed the results I got were not repeatable: even with the initial condition sampler having a fixed rng, different runs gave different results.

The culprit for this is the default `seeds_from_attractor`, which in the current version generates ics from previously found attractors to be mapped for new parameters in `basins_fractions_continuation`.  
The default function is  `_default_seeding_process`, which gets random values from the attractors, but does so without any fixed rng. As a consequence, different runs will get different ics from the attractors.
Usually this shouldn't be a problem, but I think that in cases like here in which the basins are riddled or at least complicated the different ics can actually belong to different basins, leading to different attractors getting mapped, leading to different labels and possibly different attractors being found if their basin fractions are not very large.


A simple solution is to fix the `rng` in the function, like I suggested here.
