### PR TITLE
Finish continuation interface, and allow clustering of attractors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This is the first release. It continues from ChaosTools.jl v2.9, and hence, the 
 - Added a new clause in automatic `ε` estimation in `AttractorsViaProximity` for when there is only a single attractor passed in by the user.
 
 ## Basin fractions continuation
-- New function `basins_fractions_continuation` that calculates basins fractions and how these change versus a parameter (given a continuation method)
+- New function `continuation` that calculates basins fractions and how these change versus a parameter (given a continuation method)
 - New basins fraction continuation method `RecurrencesSeededContinuation` that utilizes a brand new algorithm to continuate basins fractions of arbitrary systems.
 - `match_attractor_ids!` has been fully overhauled to be more flexible, allow more ways to match, and also allow arbitrary user-defined ways to match.
 - New function `match_basins_ids!` for matching the output of basins_of_attraction`.

--- a/docs/src/attractors.md
+++ b/docs/src/attractors.md
@@ -1,5 +1,6 @@
 # Finding Attractors
-Attractors.jl defines a generic interface for finding attractors of dynamical systems. One first decides the instance of [`GeneralizedDynamicalSystem`](@ref) they need. Then, an instance of [`AttractorMapper`](@ref) is created from this dynamical system. This `mapper` instance can be used to compute e.g., [`basins_of_attraction`](@ref), and the output can be further analyzed to get e.g., the [`basin_entropy`](@ref).
+
+Attractors.jl defines a generic interface for finding attractors of dynamical systems. One first decides the instance of [`DynamicalSystem`](@ref) they need. Then, an instance of [`AttractorMapper`](@ref) is created from this dynamical system. This `mapper` instance can be used to compute e.g., [`basins_of_attraction`](@ref), and the output can be further analyzed to get e.g., the [`basin_entropy`](@ref).
 
 ```@docs
 AttractorMapper

--- a/docs/src/continuation.md
+++ b/docs/src/continuation.md
@@ -9,7 +9,7 @@ continuation
 ## Recurrences continuation (best)
 
 ```@docs
-RecurrencesSeedingContinuation
+RecurrencesSeededContinuation
 ```
 
 ## Matching attractors

--- a/docs/src/continuation.md
+++ b/docs/src/continuation.md
@@ -3,7 +3,7 @@
 
 ## Basins continuation API
 ```@docs
-basins_fractions_continuation
+continuation
 ```
 
 ## Recurrences continuation (best)

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -128,7 +128,7 @@ the system's symmetry.
 
 
 ## Basin fractions continuation in the magnetic pendulum
-Perhaps the simplest application of [`basins_fractions_continuation`](@ref) is to produce a plot of how the fractions of attractors change as we continuously change the parameter we changed above to calculate tipping probabilities.
+Perhaps the simplest application of [`continuation`](@ref) is to produce a plot of how the fractions of attractors change as we continuously change the parameter we changed above to calculate tipping probabilities.
 
 
 
@@ -242,7 +242,7 @@ mapper = AttractorsViaRecurrences(ds, grid; recurrences_kwargs...)
 # NOTE: in a realistic applicaiton the threshold should not be infinite,
 # but some sensible distance in state space units
 continuation = RecurrencesSeedingContinuation(mapper; threshold = Inf)
-fractions_curves, attractors_info = basins_fractions_continuation(
+fractions_curves, attractors_info = continuation(
     continuation, prange, pidx, sampler;
     show_progress = true, samples_per_parameter
 );

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -241,7 +241,7 @@ mapper = AttractorsViaRecurrences(ds, grid; recurrences_kwargs...)
 # perform continuation of attractors and their basins
 # NOTE: in a realistic applicaiton the threshold should not be infinite,
 # but some sensible distance in state space units
-continuation = RecurrencesSeedingContinuation(mapper; threshold = Inf)
+continuation = RecurrencesSeededContinuation(mapper; threshold = Inf)
 fractions_curves, attractors_info = continuation(
     continuation, prange, pidx, sampler;
     show_progress = true, samples_per_parameter

--- a/src/basins/basins_utilities.jl
+++ b/src/basins/basins_utilities.jl
@@ -7,7 +7,7 @@ Return a dictionary that maps attractor IDs to their relative fractions.
 
 In[^Menck2013] the authors use these fractions to quantify the stability of a basin of
 attraction, and specifically how it changes when a parameter is changed.
-For this, see [`basins_fractions_continuation`](@ref).
+For this, see [`continuation`](@ref).
 
 [^Menck2013]:
     Menck, Heitzig, Marwan & Kurths. How basin stability complements the linear

--- a/src/continuation/aggregate_attractor_fractions.jl
+++ b/src/continuation/aggregate_attractor_fractions.jl
@@ -23,7 +23,6 @@ however, one may care about aggregating all attractors into two groups: where a 
 species is extinct or not. This is the example highlighted in our documentation,
 in [Extinction of a species in a multistable competition model](@ref).
 
-
 ## Input
 
 1. `fractions_curves`: a vector of dictionaries mapping labels to basin fractions.

--- a/src/continuation/aggregate_attractor_fractions.jl
+++ b/src/continuation/aggregate_attractor_fractions.jl
@@ -35,7 +35,7 @@ in [Extinction of a species in a multistable competition model](@ref).
    _However_, you may also use the DBSCAN clustering approach here to group attractors
    based on their state space distance (the [`set_distance`](@ref)).
    For this, use `identity` as `featurizer`, and use
-   `clust_distance_metric = (A, B) -> set_distance(A, B)` when initializing the
+   `clust_distance_metric = set_distance` when initializing the
    [`GroupViaClustering`](@ref) configuration.
 4. `group_config`: a subtype of [`GroupingConfig`](@ref).
 5. `info_extraction`: a function accepting a vector of features and returning a description

--- a/src/continuation/aggregate_attractor_fractions.jl
+++ b/src/continuation/aggregate_attractor_fractions.jl
@@ -32,11 +32,6 @@ in [Extinction of a species in a multistable competition model](@ref).
    (or, they can be the return of [`basins_fractions`](@ref)).
 3. `featurizer`: a 1-argument function to map an attractor into an appropriate feature
    to be grouped later. Features expected by [`GroupingConfig`](@ref) are `SVector`.
-   _However_, you may also use the DBSCAN clustering approach here to group attractors
-   based on their state space distance (the [`set_distance`](@ref)).
-   For this, use `identity` as `featurizer`, and use
-   `clust_distance_metric = set_distance` when initializing the
-   [`GroupViaClustering`](@ref) configuration.
 4. `group_config`: a subtype of [`GroupingConfig`](@ref).
 5. `info_extraction`: a function accepting a vector of features and returning a description
    of the features. I.e., exactly as in [`GroupAcrossParameterContinuation`](@ref).
@@ -48,6 +43,20 @@ in [Extinction of a species in a multistable competition model](@ref).
    aggregated attractors.
 2. `aggregated_info`: dictionary mapping the new labels of `aggregated_fractions` to the
    extracted information using `info_extraction`.
+
+## Clustering attractors directly
+
+_(this is rather advanced)_
+
+You may also use the DBSCAN clustering approach here to group attractors
+based on their state space distance (the [`set_distance`](@ref)) by making a distance
+matrix as expected by the DBSCAN implementation.
+For this, use `identity` as `featurizer`, and choose [`GroupViaClustering`](@ref)
+as the `group_config` with `clust_distance_metric = set_distance` and provide a numerical
+value for `optimal_radius_method` when initializing the [`GroupViaClustering`](@ref),
+and also, for the `info_extraction` argument, you now need to provide a function that
+expects a _vector of `StateSpaceSet`s_ and outputs a descriptor.
+E.g., `info_extraction = vector -> mean(mean(x) for x in vector)`.
 """
 function aggregate_attractor_fractions(
         fractions_curves::Vector, attractors_info::Vector, featurizer, group_config,

--- a/src/continuation/aggregate_attractor_fractions.jl
+++ b/src/continuation/aggregate_attractor_fractions.jl
@@ -8,7 +8,7 @@ export aggregate_attractor_fractions
 Aggregate the already-estimated curves of fractions of basins of attraction of similar
 attractors using the same pipeline used by [`GroupingConfig`](@ref).
 The most typical application of this function is to transform the output of
-[`RecurrencesSeedingContinuation`](@ref) so that similar attractors, even across parameter
+[`RecurrencesSeededContinuation`](@ref) so that similar attractors, even across parameter
 space, are grouped into one "attractor". Thus, the fractions of their basins are aggregated.
 
 You could also use this function to aggregate attractors and their fractions even in
@@ -19,16 +19,21 @@ This function is useful in cases where you want the accuracy and performance of
 similar attractrors like in [`AttractorsViaFeaturizing`](@ref) for presentation or
 analysis purposes. For example, a high dimesional model of competition dynamics
 across multispecies may have extreme multistability. After finding this multistability
-However, one may care
-about aggregating all attractors into two groups: where a given species is
-extinct or not. This is the example highlighted in our documentation,
+however, one may care about aggregating all attractors into two groups: where a given
+species is extinct or not. This is the example highlighted in our documentation,
 in [Extinction of a species in a multistable competition model](@ref).
 
+*Note:* you can even use the DBSCAN clustering approach here to group attractors.
+Use `identity` as `featurizer`, and use
+`clust_distance_metric = (A, B) -> set_distance(A, B)` when initializing the
+[`GroupViaClustering`](@ref) configuration.
+
 ## Input
+
 1. `fractions_curves`: a vector of dictionaries mapping labels to basin fractions.
 2. `attractors_info`: a vector of dictionaries mapping labels to attractors.
    1st and 2nd argument are exactly like the return values of
-   [`continuation`](@ref) with [`RecurrencesSeedingContinuation`](@ref)
+   [`continuation`](@ref) with [`RecurrencesSeededContinuation`](@ref)
    (or, they can be the return of [`basins_fractions`](@ref)).
 3. `featurizer`: a 1-argument function to map an attractor into a feature `SVector`.
    Notice that you can use `identity` if the input "attractors" aren't actually attractors
@@ -39,6 +44,7 @@ in [Extinction of a species in a multistable competition model](@ref).
    The 5th argument is optional and defaults to the centroid of the features.
 
 ## Return
+
 1. `aggregated_fractions`: same as `fractions_curves` but now contains the fractions of the
    aggregated attractors.
 2. `aggregated_info`: dictionary mapping the new labels of `aggregated_fractions` to the

--- a/src/continuation/aggregate_attractor_fractions.jl
+++ b/src/continuation/aggregate_attractor_fractions.jl
@@ -23,10 +23,6 @@ however, one may care about aggregating all attractors into two groups: where a 
 species is extinct or not. This is the example highlighted in our documentation,
 in [Extinction of a species in a multistable competition model](@ref).
 
-*Note:* you can even use the DBSCAN clustering approach here to group attractors.
-Use `identity` as `featurizer`, and use
-`clust_distance_metric = (A, B) -> set_distance(A, B)` when initializing the
-[`GroupViaClustering`](@ref) configuration.
 
 ## Input
 
@@ -35,9 +31,13 @@ Use `identity` as `featurizer`, and use
    1st and 2nd argument are exactly like the return values of
    [`continuation`](@ref) with [`RecurrencesSeededContinuation`](@ref)
    (or, they can be the return of [`basins_fractions`](@ref)).
-3. `featurizer`: a 1-argument function to map an attractor into a feature `SVector`.
-   Notice that you can use `identity` if the input "attractors" aren't actually attractors
-   but already features or something else that can be grouped directly.
+3. `featurizer`: a 1-argument function to map an attractor into an appropriate feature
+   to be grouped later. Features expected by [`GroupingConfig`](@ref) are `SVector`.
+   _However_, you may also use the DBSCAN clustering approach here to group attractors
+   based on their state space distance (the [`set_distance`](@ref)).
+   For this, use `identity` as `featurizer`, and use
+   `clust_distance_metric = (A, B) -> set_distance(A, B)` when initializing the
+   [`GroupViaClustering`](@ref) configuration.
 4. `group_config`: a subtype of [`GroupingConfig`](@ref).
 5. `info_extraction`: a function accepting a vector of features and returning a description
    of the features. I.e., exactly as in [`GroupAcrossParameterContinuation`](@ref).

--- a/src/continuation/aggregate_attractor_fractions.jl
+++ b/src/continuation/aggregate_attractor_fractions.jl
@@ -28,7 +28,7 @@ in [Extinction of a species in a multistable competition model](@ref).
 1. `fractions_curves`: a vector of dictionaries mapping labels to basin fractions.
 2. `attractors_info`: a vector of dictionaries mapping labels to attractors.
    1st and 2nd argument are exactly like the return values of
-   [`basins_fractions_continuation`](@ref) with [`RecurrencesSeedingContinuation`](@ref)
+   [`continuation`](@ref) with [`RecurrencesSeedingContinuation`](@ref)
    (or, they can be the return of [`basins_fractions`](@ref)).
 3. `featurizer`: a 1-argument function to map an attractor into a feature `SVector`.
    Notice that you can use `identity` if the input "attractors" aren't actually attractors

--- a/src/continuation/basins_fractions_continuation_api.jl
+++ b/src/continuation/basins_fractions_continuation_api.jl
@@ -1,13 +1,13 @@
-export basins_fractions_continuation
+export continuation
 
 # In the end, it is better to have a continuation type that contains
 # how to match, because there are other keywords that always go into the
 # continuation... Like in the recurrences the keyword of seeds per attractor,
 # or in the clustering some other stuff like the parameter scaling
-abstract type BasinsFractionContinuation end
+abstract type AttractorsBasinsContinuation end
 
 """
-    basins_fractions_continuation(continuation, prange, pidx, ics; kwargs...)
+   continuation(continuation, prange, pidx, ics; kwargs...)
 
 Find and continue attractors and the fractions of their basins of attraction
 across a parameter range.
@@ -44,7 +44,7 @@ initial conditions or a dataset containing them.
 - [`GroupAcrossParameterContinuation`](@ref).
 
 """
-function basins_fractions_continuation end
+function continuation end
 
 include("match_attractor_ids.jl")
 include("continuation_recurrences.jl")

--- a/src/continuation/basins_fractions_continuation_api.jl
+++ b/src/continuation/basins_fractions_continuation_api.jl
@@ -7,42 +7,36 @@ export continuation
 abstract type AttractorsBasinsContinuation end
 
 """
-   continuation(continuation, prange, pidx, ics; kwargs...)
+   continuation(abc::AttractorsBasinsContinuation, prange, pidx, ics; kwargs...)
 
-Find and continue attractors and the fractions of their basins of attraction
-across a parameter range.
-The given `continuation` contains a reference to a dynamical system,
-as well as how to find its attractors. I.e., it contains an [`AttractorMapper`](@ref).
-Given this `continuation`, the basin fractions (and the attractors for the
-`RecurrencesSeedingContinuation` method) are continued across the parameter range `prange`,
+Find and continue attractors (or feature-based representations of attractors)
+and the fractions of their basins of attraction across a parameter range.
+
+The continuation type `abc` is a subtype of [`AttractorsBasinsContinuation`](@ref)
+and contains an [`AttractorMapper`](@ref). The mapper contains information
+on how to find the attractors and basins of a dynamical system. Additional
+arguments and keyword arguments given when creating `abc` further tune the continuation.
+
+In the `continuation` function, the basin fractions and the attractors (or some representation
+of them in the case of featurizing) are continued across the parameter range `prange`,
 for the parameter of the system with index `pidx`.
 `ics` is as in [`basins_fractions`](@ref), i.e., it is either a function generating
-initial conditions or a dataset containing them.
+initial conditions or a set containing them.
 
 ## Return
 
-1. `fractions_curves <: Vector{Dict{Int, Float64}}`. The fractions of basins of attraction.
+1. `fractions_curves :: Vector{Dict{Int, Float64}}`. The fractions of basins of attraction.
    `fractions_curves[i]` is a dictionary mapping attractor IDs to their basin fraction
    at the `i`-th parameter.
 2. `attractors_info <: Vector{Dict{Int, <:Any}}`. Information about the attractors.
    `attractors_info[i]` is a dictionary mapping attractor ID to information about the
    attractor at the `i`-th parameter.
-   The type of information stored depends on the chosen continuation method.
+   The type of information stored depends on the chosen continuation type.
 
 ## Keyword arguments
 
-* `samples_per_parameter = 100`: Amount of initial conditions sampled at each parameter.
-* `show_progress = true`: Whether to show a progress bar for the process.
-
-## Continuation methods
-
-- [`RecurrencesSeedingContinuation`](@ref). For this sampler, `ics` is optional.
-  If not given, one is created using the `grid` of [`AttractorsViaRecurrences`](@ref):
-  ```
-  sampler, = statespace_sampler(min_bounds = minimum.(grid), max_bounds = maximum.(grid))
-  ```
-- [`GroupAcrossParameterContinuation`](@ref).
-
+- `show_progress = true`: display a progress bar of the computation.
+* `samples_per_parameter = 100`: amount of initial conditions sampled at each parameter.
 """
 function continuation end
 

--- a/src/continuation/continuation_grouping.jl
+++ b/src/continuation/continuation_grouping.jl
@@ -2,7 +2,7 @@ export GroupAcrossParameterContinuation
 import ProgressMeter
 import Mmap
 
-struct GroupAcrossParameterContinuation{A<:AttractorsViaFeaturizing, E} <: BasinsFractionContinuation
+struct GroupAcrossParameterContinuation{A<:AttractorsViaFeaturizing, E} <: AttractorsBasinsContinuation
     mapper::A
     info_extraction::E
     par_weight::Float64
@@ -11,10 +11,10 @@ end
 """
     GroupAcrossParameterContinuation(mapper::AttractorsViaFeaturizing; kwargs...)
 
-A method for [`basins_fractions_continuation`](@ref).
+A method for [`continuation`](@ref).
 It uses the featurizing approach discussed in [`AttractorsViaFeaturizing`](@ref)
 and hence requires an instance of that mapper as an input.
-When used in [`basins_fractions_continuation`](@ref), features are extracted
+When used in [`continuation`](@ref), features are extracted
 and then grouped across a parameter range. Said differently, all features
 of all initial conditions across all parameter values are put into the same "pool"
 and then grouped as dictated by the `group_config` of the mapper.
@@ -65,7 +65,7 @@ function mean_across_features(fs)
     return means ./ N
 end
 
-function basins_fractions_continuation(
+function continuation(
         continuation::GroupAcrossParameterContinuation, prange, pidx, ics;
         show_progress = true, samples_per_parameter = 100
     )

--- a/src/continuation/continuation_recurrences.jl
+++ b/src/continuation/continuation_recurrences.jl
@@ -13,18 +13,39 @@ struct RecurrencesSeedingContinuation{A, M, S, E} <: AttractorsBasinsContinuatio
 end
 
 """
-    RecurrencesSeedingContinuation(mapper::AttractorsViaRecurrences; kwargs...)
-A method for [`continuation`](@ref).
-It uses seeding of previous attractors to find new ones, which is the main performance
-bottleneck. The method uses [`match_attractor_ids!`](@ref) to match attractors
-as the system parameter is increased.
+    RecurrencesSeededContinuation <: AttractorsBasinsContinuation
+    RecurrencesSeededContinuation(mapper::AttractorsViaRecurrences; kwargs...)
 
-Will write more once we have the paper going.
+A method for [`continuation`](@ref). TODO: Cite our preprint here.
 
-## Keyword Arguments
-- `method, threshold`: Given to [`match_attractor_ids!`](@ref) which is the function
-  used to match attractors between each parameter slice.
-- `info_extraction = identity`: A function that takes as an input an attractor (`Dataset`)
+## Description
+
+At the first parameter slice attractors are found as described in the
+[`AttractorsViaRecurrences`](@ref) mapper using recurrences in state space.
+At each subsequent parameter slice,
+new attractors are found by seeding initial conditions from the previously found
+attractors and then piping these initial conditions through the recurrences algorithm
+of the `mapper`. Seeding initial conditions close to previous attractors accelerates
+the main bottleneck of [`AttractorsViaRecurrences`](@ref), which is finding the attractors.
+This process continues until all parameter values are exhausted and for each parameter
+value the attractors and their fractions are found.
+
+Then, the different attractors across parameters are matched so that they have
+the same ID. The matching process is based on distances attractors (= sets in state space)
+have between each other. The function that computes these distances is
+[`setsofsets_distances`](@ref) and the matching function
+is [`match_attractor_ids!`](@ref) please read those docstrings before continuing).
+
+At each parameter slice beyond the first, the new
+attractors are matched to the previous attractors found in the previous parameter value
+by a direct call to the [`match_attractor_ids!`](@ref) function. Hence, the matching
+of attractors here works "slice by slice" on the parameter axis and the attractors
+that are closest to each other (in state space, but for two different parameter values)
+get assigned the same label.
+
+## Keyword arguments
+- `distance, threshold`: propagated to [`match_attractor_ids!`](@ref).
+- `info_extraction = identity`: A function that takes as an input an attractor (`StateSpaceSet`)
   and outputs whatever information should be stored. It is used to return the
   `attractors_info` in [`continuation`](@ref).
 - `seeds_from_attractor`: A function that takes as an input an attractor and returns

--- a/src/continuation/continuation_recurrences.jl
+++ b/src/continuation/continuation_recurrences.jl
@@ -4,7 +4,7 @@ using Random: MersenneTwister
 
 # The recurrences based method is rather flexible because it works
 # in two independent steps: it first finds attractors and then matches them.
-struct RecurrencesSeedingContinuation{A, M, S, E} <: BasinsFractionContinuation
+struct RecurrencesSeedingContinuation{A, M, S, E} <: AttractorsBasinsContinuation
     mapper::A
     method::M
     threshold::Float64
@@ -14,7 +14,7 @@ end
 
 """
     RecurrencesSeedingContinuation(mapper::AttractorsViaRecurrences; kwargs...)
-A method for [`basins_fractions_continuation`](@ref).
+A method for [`continuation`](@ref).
 It uses seeding of previous attractors to find new ones, which is the main performance
 bottleneck. The method uses [`match_attractor_ids!`](@ref) to match attractors
 as the system parameter is increased.
@@ -26,7 +26,7 @@ Will write more once we have the paper going.
   used to match attractors between each parameter slice.
 - `info_extraction = identity`: A function that takes as an input an attractor (`Dataset`)
   and outputs whatever information should be stored. It is used to return the
-  `attractors_info` in [`basins_fractions_continuation`](@ref).
+  `attractors_info` in [`continuation`](@ref).
 - `seeds_from_attractor`: A function that takes as an input an attractor and returns
   an iterator of initial conditions to be seeded from the attractor for the next
   parameter slice. By default, we sample some points from existing attractors according
@@ -50,7 +50,7 @@ function _default_seeding_process(attractor::AbstractDataset; rng = MersenneTwis
     return (rand(rng, attractor.data) for _ in 1:seeds)
 end
 
-function basins_fractions_continuation(
+function continuation(
         continuation::RecurrencesSeedingContinuation,
         prange, pidx, ics = _ics_from_grid(continuation);
         samples_per_parameter = 100, show_progress = true,

--- a/src/continuation/continuation_recurrences.jl
+++ b/src/continuation/continuation_recurrences.jl
@@ -20,21 +20,23 @@ A method for [`continuation`](@ref). TODO: Cite our preprint here.
 
 ## Description
 
-At the first parameter slice attractors are found as described in the
+At the first parameter slice attractors and their fractions are found as described in the
 [`AttractorsViaRecurrences`](@ref) mapper using recurrences in state space.
 At each subsequent parameter slice,
 new attractors are found by seeding initial conditions from the previously found
 attractors and then piping these initial conditions through the recurrences algorithm
 of the `mapper`. Seeding initial conditions close to previous attractors accelerates
 the main bottleneck of [`AttractorsViaRecurrences`](@ref), which is finding the attractors.
+After the attractors are found, their fractions are computed by running new initial
+conditions through the [`AttractorsViaRecurrences`](@ref) mapper.
 This process continues until all parameter values are exhausted and for each parameter
 value the attractors and their fractions are found.
 
 Then, the different attractors across parameters are matched so that they have
-the same ID. The matching process is based on distances attractors (= sets in state space)
-have between each other. The function that computes these distances is
+the same ID. The matching process is based on distances between attractors.
+The function that computes these distances is
 [`setsofsets_distances`](@ref) and the matching function
-is [`match_attractor_ids!`](@ref) please read those docstrings before continuing).
+is [`match_attractor_ids!`](@ref) (please read those docstrings as well).
 
 At each parameter slice beyond the first, the new
 attractors are matched to the previous attractors found in the previous parameter value

--- a/src/continuation/continuation_recurrences.jl
+++ b/src/continuation/continuation_recurrences.jl
@@ -1,10 +1,10 @@
-export RecurrencesSeedingContinuation
+export RecurrencesSeededContinuation
 import ProgressMeter
 using Random: MersenneTwister
 
 # The recurrences based distance is rather flexible because it works
 # in two independent steps: it first finds attractors and then matches them.
-struct RecurrencesSeedingContinuation{A, M, S, E} <: AttractorsBasinsContinuation
+struct RecurrencesSeededContinuation{A, M, S, E} <: AttractorsBasinsContinuation
     mapper::A
     distance::M
     threshold::Float64
@@ -56,12 +56,12 @@ get assigned the same label.
   to how many points the attractors themselves contain. A maximum of `10` seeds is done
   per attractor.
 """
-function RecurrencesSeedingContinuation(
+function RecurrencesSeededContinuation(
         mapper::AttractorsViaRecurrences; distance = Centroid(),
         threshold = Inf, seeds_from_attractor = _default_seeding_process,
         info_extraction = identity
     )
-    return RecurrencesSeedingContinuation(
+    return RecurrencesSeededContinuation(
         mapper, distance, threshold, seeds_from_attractor, info_extraction
     )
 end
@@ -74,7 +74,7 @@ function _default_seeding_process(attractor::AbstractDataset; rng = MersenneTwis
 end
 
 function continuation(
-        continuation::RecurrencesSeedingContinuation,
+        continuation::RecurrencesSeededContinuation,
         prange, pidx, ics = _ics_from_grid(continuation);
         samples_per_parameter = 100, show_progress = true,
     )
@@ -166,7 +166,7 @@ function reset!(mapper::AttractorsViaRecurrences)
     return
 end
 
-function _ics_from_grid(continuation::RecurrencesSeedingContinuation)
+function _ics_from_grid(continuation::RecurrencesSeededContinuation)
     return _ics_from_grid(continuation.mapper.grid)
 end
 

--- a/src/continuation/continuation_recurrences.jl
+++ b/src/continuation/continuation_recurrences.jl
@@ -2,11 +2,11 @@ export RecurrencesSeedingContinuation
 import ProgressMeter
 using Random: MersenneTwister
 
-# The recurrences based method is rather flexible because it works
+# The recurrences based distance is rather flexible because it works
 # in two independent steps: it first finds attractors and then matches them.
 struct RecurrencesSeedingContinuation{A, M, S, E} <: AttractorsBasinsContinuation
     mapper::A
-    method::M
+    distance::M
     threshold::Float64
     seeds_from_attractor::S
     info_extraction::E
@@ -55,12 +55,12 @@ get assigned the same label.
   per attractor.
 """
 function RecurrencesSeedingContinuation(
-        mapper::AttractorsViaRecurrences; method = Centroid(),
+        mapper::AttractorsViaRecurrences; distance = Centroid(),
         threshold = Inf, seeds_from_attractor = _default_seeding_process,
         info_extraction = identity
     )
     return RecurrencesSeedingContinuation(
-        mapper, method, threshold, seeds_from_attractor, info_extraction
+        mapper, distance, threshold, seeds_from_attractor, info_extraction
     )
 end
 
@@ -82,7 +82,7 @@ function continuation(
         desc="Continuating basins fractions:", enabled=show_progress
     )
 
-    (; mapper, method, threshold) = continuation
+    (; mapper, distance, threshold) = continuation
     # first parameter is run in isolation, as it has no prior to seed from
     set_parameter!(mapper.ds, pidx, prange[1])
     fs = basins_fractions(mapper, ics; show_progress = false, N = samples_per_parameter)
@@ -126,7 +126,7 @@ function continuation(
             # If there are any attractors,
             # match with previous attractors before storing anything!
             rmap = match_attractor_ids!(
-                current_attractors, prev_attractors; method, threshold
+                current_attractors, prev_attractors; distance, threshold
             )
             swap_dict_keys!(fs, rmap)
         end

--- a/src/continuation/match_attractor_ids.jl
+++ b/src/continuation/match_attractor_ids.jl
@@ -26,7 +26,7 @@ the different parameters) with different IDs.
 `match_attractors_ids!` tries to "match" them by modifying the attractor IDs,
 i.e., the keys of the given dictionaries.
 
-The matching happens according to the output of the [`setsofsets_distance`](@ref)
+The matching happens according to the output of the [`setsofsets_distances`](@ref)
 function with the keyword `distance`. distance` can be whatever that function accepts.
 Attractors are then match according to distance, with unique mapping.
 The closest attractors (before and after) are mapped to each
@@ -57,7 +57,7 @@ Return a dictionary mapping keys in `a₊` to new keys in `a₋`,
 as explained in [`match_attractor_ids!`](@ref).
 """
 function replacement_map(a₊::Dict, a₋::Dict; distance = Centroid(), threshold = Inf)
-    distances = setsofsets_distance(a₊, a₋, distance)
+    distances = setsofsets_distances(a₊, a₋, distance)
     keys₊, keys₋ = keys.((a₊, a₋))
     replacement_map(keys₊, keys₋, distances::Dict, threshold)
 end

--- a/src/continuation/match_attractor_ids.jl
+++ b/src/continuation/match_attractor_ids.jl
@@ -5,7 +5,8 @@ export match_attractor_ids!, match_basins_ids!, replacement_map
 # Matching attractors and key swapping business
 ###########################################################################################
 """
-    match_attractor_ids!(a₊::AbstractDict, a₋; method = Centroid(), threshold = Inf)
+    match_attractor_ids!(a₊::AbstractDict, a₋; distance = Centroid(), threshold = Inf)
+
 Given dictionaries `a₊, a₋` mapping IDs to attractors (`Dataset` instances),
 match attractor IDs in dictionary `a₊` so that its attractors that are the closest to
 those in dictionary `a₋` get assigned the same key as in `a₋`.
@@ -26,7 +27,7 @@ the different parameters) with different IDs.
 i.e., the keys of the given dictionaries.
 
 The matching happens according to the output of the [`setsofsets_distance`](@ref)
-function with the keyword `method`. method` can be whatever that function accepts.
+function with the keyword `distance`. distance` can be whatever that function accepts.
 Attractors are then match according to distance, with unique mapping.
 The closest attractors (before and after) are mapped to each
 other, and are removed from the matching pool, and then the next pair with least
@@ -51,12 +52,12 @@ function match_attractor_ids!(as::Vector{<:Dict}; kwargs...)
 end
 
 """
-    replacement_map(a₊, a₋; method = Centroid(), threshold = Inf) → rmap
+    replacement_map(a₊, a₋; distance = Centroid(), threshold = Inf) → rmap
 Return a dictionary mapping keys in `a₊` to new keys in `a₋`,
 as explained in [`match_attractor_ids!`](@ref).
 """
-function replacement_map(a₊::Dict, a₋::Dict; method = Centroid(), threshold = Inf)
-    distances = setsofsets_distance(a₊, a₋, method)
+function replacement_map(a₊::Dict, a₋::Dict; distance = Centroid(), threshold = Inf)
+    distances = setsofsets_distance(a₊, a₋, distance)
     keys₊, keys₋ = keys.((a₊, a₋))
     replacement_map(keys₊, keys₋, distances::Dict, threshold)
 end

--- a/src/dict_utils.jl
+++ b/src/dict_utils.jl
@@ -69,7 +69,7 @@ then they will transformed to 1, 2, 3.
 Return the replacement map used to replace keys in all dictionaries with
 [`swap_dict_keys!`](@ref).
 
-As this function is used in attractor matching in [`basins_fractions_continuation`](@ref)
+As this function is used in attractor matching in [`continuation`](@ref)
 it skips the special key `-1`.
 """
 function retract_keys_to_consecutive(v::Vector{<:Dict})

--- a/src/mapping/grouping/all_grouping_configs.jl
+++ b/src/mapping/grouping/all_grouping_configs.jl
@@ -35,7 +35,7 @@ Group the given vector of feature vectors according to the configuration and ret
 the labels (vector of equal length as `features`).
 See [`AttractorsViaFeaturizing`](@ref) for possible configurations.
 """
-function group_features(features::Vector{<:AbstractVector}, group_config::GroupingConfig)
+function group_features(features, group_config::GroupingConfig)
     return map(f -> feature_to_group(f, group_config), features)
 end
 

--- a/src/mapping/grouping/cluster_config.jl
+++ b/src/mapping/grouping/cluster_config.jl
@@ -166,8 +166,12 @@ function _distance_matrix(features, config::GroupViaClustering;
     if metric isa Metric # then the `pairwise` function is valid
         pairwise!(metric, dists, features; symmetric = true)
     else # it is any arbitrary distance function, e.g., used in aggregating attractors
-        # TODO:
-        pairwise_optimized()
+        for i in eachindex(features)
+            for j in i:length(features)
+                distances[i, j] = metric(features[i], features[j])
+                distances[j, i] = distances[i, j] # symmetry
+            end
+        end
     end
 
     if par_weight ≠ 0 # weight distance matrix by parameter value

--- a/src/mapping/grouping/cluster_config.jl
+++ b/src/mapping/grouping/cluster_config.jl
@@ -227,7 +227,7 @@ Do "min-max" rescaling of vector of feature vectors so that its values span `[0,
 """
 _rescale_to_01(features::Vector{<:AbstractVector}) = _rescale_to_01(Dataset(features))
 function _rescale_to_01(features::AbstractDataset)
-    mini, maxi = minmaxima(dataset)
+    mini, maxi = minmaxima(features)
     return map(f -> f .* (maxi .- mini) .+ mini, features)
 end
 

--- a/src/mapping/grouping/cluster_config.jl
+++ b/src/mapping/grouping/cluster_config.jl
@@ -14,7 +14,9 @@ The defaults are a significant improvement over existing literature, see Descrip
 
 ## Keyword arguments
 
-* `clust_distance_metric = Euclidean()`: metric to be used in the clustering.
+* `clust_distance_metric = Euclidean()`: A metric to be used in the clustering.
+  It can be any function `f(a, b)` that returns the distance between vectors
+  `a, b`. All metrics from Distances.jl can be used here.
 * `rescale_features = true`: if true, rescale each dimension of the extracted features
   separately into the range `[0,1]`. This typically leads to more accurate clustering.
 * `min_neighbors = 10`: minimum number of neighbors (i.e. of similar features) each
@@ -161,7 +163,13 @@ function _distance_matrix(features, config::GroupViaClustering;
     else
         dists = zeros(L, L)
     end
-    pairwise!(metric, dists, features; symmetric = true)
+    if metric isa Metric # then the `pairwise` function is valid
+        pairwise!(metric, dists, features; symmetric = true)
+    else # it is any arbitrary distance function, e.g., used in aggregating attractors
+        # TODO:
+        pairwise_optimized()
+    end
+
     if par_weight ≠ 0 # weight distance matrix by parameter value
         par_vector = kron(range(0, 1, plength), ones(spp))
         length(par_vector) ≠ size(dists, 1) && error("Feature size doesn't match.")

--- a/src/mapping/grouping/cluster_config.jl
+++ b/src/mapping/grouping/cluster_config.jl
@@ -166,8 +166,8 @@ function _distance_matrix(features, config::GroupViaClustering;
     if metric isa Metric # then the `pairwise` function is valid
         pairwise!(metric, dists, features; symmetric = true)
     else # it is any arbitrary distance function, e.g., used in aggregating attractors
-        for i in eachindex(features)
-            for j in i:length(features)
+        @inbounds for i in eachindex(features)
+            Threads.@threads for j in i:length(features)
                 distances[i, j] = metric(features[i], features[j])
                 distances[j, i] = distances[i, j] # symmetry
             end

--- a/test/continuation/grouping_continuation.jl
+++ b/test/continuation/grouping_continuation.jl
@@ -37,7 +37,7 @@ using Random
     clusterspecs = Attractors.GroupViaClustering(optimal_radius_method = "silhouettes", max_used_features = 200)
     mapper = Attractors.AttractorsViaFeaturizing(ds, featurizer, clusterspecs; T = 20, threaded = true)
     continuation = GroupAcrossParameterContinuation(mapper; par_weight = 1.)
-    fractions_curves, attractors_info = Attractors.basins_fractions_continuation(
+    fractions_curves, attractors_info = Attractors.continuation(
     continuation, rrange, ridx, sampler; show_progress = false)
 
 
@@ -90,7 +90,7 @@ if DO_EXTENSIVE_TESTS
         clusterspecs = Attractors.GroupViaClustering(optimal_radius_method = 1.)
         mapper = Attractors.AttractorsViaFeaturizing(ds, featurizer, clusterspecs; T = 500, threaded = true)
         continuation = GroupAcrossParameterContinuation(mapper; par_weight = 1.0)
-        fractions_curves, attractors_info = Attractors.basins_fractions_continuation(
+        fractions_curves, attractors_info = Attractors.continuation(
             continuation, ps, pidx, sampler;
             samples_per_parameter = 1000, show_progress = false
         )

--- a/test/continuation/recurrences_continuation.jl
+++ b/test/continuation/recurrences_continuation.jl
@@ -21,7 +21,7 @@ using Random
         # test that both finding and removing attractor works
         mapper = AttractorsViaRecurrences(ds, (xg, yg); sparse=false, Δt = 1.0)
 
-        continuation = RecurrencesSeedingContinuation(mapper; threshold = Inf)
+        continuation = RecurrencesSeededContinuation(mapper; threshold = Inf)
         # With this threshold all attractors are mapped to each other, they are within
         # distance 1 in state space.
         fractions_curves, attractors_info = continuation(
@@ -117,7 +117,7 @@ if DO_EXTENSIVE_TESTS
         mx_chk_fnd_att = 3000,
         mx_chk_loc_att = 3000
     )
-    continuation = RecurrencesSeedingContinuation(mapper;
+    continuation = RecurrencesSeededContinuation(mapper;
         threshold = 0.99, method = distance_function
     )
     ps = psorig
@@ -185,7 +185,7 @@ end
         min_bounds = [-2,-2], max_bounds = [2,2]
     )
     mapper = AttractorsViaRecurrences(ds, (xg, yg); sparse=false)
-    continuation = RecurrencesSeedingContinuation(mapper)
+    continuation = RecurrencesSeededContinuation(mapper)
     fractions_curves, attractors_info = continuation(
         continuation, ps, pidx, sampler;
         show_progress = false, samples_per_parameter = 100
@@ -227,7 +227,7 @@ end
 
     rrange = range(0., 2; length = 20)
     ridx = 1
-    continuation = Attractors.RecurrencesSeedingContinuation(mapper; threshold = 0.3)
+    continuation = Attractors.RecurrencesSeededContinuation(mapper; threshold = 0.3)
     fractions_curves, a = Attractors.continuation(
         continuation, rrange, ridx, sampler;
         show_progress = false, samples_per_parameter = 1000

--- a/test/continuation/recurrences_continuation.jl
+++ b/test/continuation/recurrences_continuation.jl
@@ -298,6 +298,7 @@ end
 
 
 @testset "magnetic pendulum" begin
+    using PredefinedDynamicalSystems
     d, α, ω = 0.3, 0.2, 0.5
     ds = Systems.magnetic_pendulum(; d, α, ω)
     xg = yg = range(-3, 3; length = 101)

--- a/test/continuation/recurrences_continuation.jl
+++ b/test/continuation/recurrences_continuation.jl
@@ -1,89 +1,176 @@
-# This file also tests `aggregate_attractor_fractions`
+# This file also tests `aggregate_attractor_fractions`!
 
 DO_EXTENSIVE_TESTS = get(ENV, "ATTRACTORS_EXTENSIVE_TESTS", "false") == "true"
 
 using Test, Attractors
-using Attractors.DynamicalSystemsBase
 using Random
 
-@testset "magnetic pendulum" begin
-    d, α, ω = 0.3, 0.2, 0.5
-    ds = Systems.magnetic_pendulum(; d, α, ω)
-    xg = yg = range(-3, 3; length = 101)
-    ds = ProjectedDynamicalSystem(ds, 1:2, [0.0, 0.0])
-    mapper = AttractorsViaRecurrences(ds, (xg, yg); Δt = 1.0)
-    rr = range(1, 0; length = 101)
-    psorig = [[1, 1, γ] for γ in rr]
-    pidx = :γs
-    # important to make a sampler that respects the symmetry of the system
-    sampler, isinside = statespace_sampler(Xoshiro(1234); spheredims = 2, radius = 3.0)
-    for (j, ps) in enumerate((psorig, reverse(psorig)))
-        # test that both finding and removing attractor works
-        mapper = AttractorsViaRecurrences(ds, (xg, yg); sparse=false, Δt = 1.0)
+@testset "analytic bistable map" begin
+    # This is a fake bistable map that has two equilibrium points
+    # for r > 0.5. It has predictable fractions.
+    function dumb_map(dz, z, p, n)
+        x,y = z
+        r = p[1]
 
-        continuation = RecurrencesSeededContinuation(mapper; threshold = Inf)
-        # With this threshold all attractors are mapped to each other, they are within
-        # distance 1 in state space.
-        fractions_curves, attractors_info = continuation(
-            continuation, ps, pidx, sampler; show_progress = false, samples_per_parameter = 1000
-        )
+        if r < 0.5
+            dz[1] = dz[2] = 0.0
+        else
+            if x > 0
+                dz[1] = r
+                dz[2] = r
+            else
+                dz[1] = -r
+                dz[2] = -r
+            end
+        end
+        return
+    end
 
-        # Keys of the two attractors that always exist
-        twokeys = collect(keys(fractions_curves[(j == 2 ? 1 : 101)]))
+    r = 1.0
+    ds = DeterministicIteratedMap(dumb_map, [0., 0.], [r])
+    yg = xg = range(-10., 10, length = 100)
+    grid = (xg,yg)
+    mapper = AttractorsViaRecurrences(ds, grid; sparse = true, show_progress = false)
 
-        @testset "symmetry respect" begin
-            # Initially fractions are all 0.33 but at the end only two of 0.5 remain
-            # because only two attractors remain (with equal magnetic pull)
-            startfracs, endfracs = j == 1 ? [0.33, 0.5] : [0.5, 0.33]
-            @test all(v -> isapprox(v, startfracs; atol = 1e-1), values(fractions_curves[1]))
-            @test all(v -> isapprox(v, endfracs; atol = 1e-1), values(fractions_curves[end]))
+    sampler, = statespace_sampler(Random.MersenneTwister(1234);
+        min_bounds = minimum.(grid), max_bounds = maximum.(grid))
+
+    rrange = range(0, 2; length = 20)
+    ridx = 1
+    rsc = RecurrencesSeededContinuation(mapper; threshold = 0.3)
+    fractions_curves, a = continuation(
+        rsc, rrange, ridx, sampler;
+        show_progress = false, samples_per_parameter = 1000
+    )
+
+    for (i, r) in enumerate(rrange)
+
+        fs = fractions_curves[i]
+        if r < 0.5
+            k = sort!(collect(keys(fs)))
+            @test length(k) == 1
+        else
+            k = sort!(collect(keys(fs)))
+            @test length(k) == 2
+            v = values(fs)
+            for f in v
+                @test (0.4 < f < 0.6)
+            end
+        end
+        @test sum(values(fs)) ≈ 1
+    end
+
+end
+
+
+@testset "Multistable grouping map" begin
+    # This is a fake multistable map helps at testing the grouping
+    # capabilities. We know what it does analytically!
+    function dumb_map(dz, z, p, n)
+        x,y = z
+        r = p[1]
+
+        θ = mod(angle(x + im*y),2pi)
+        rr = abs(x+ im*y)
+
+        # This map works as follows: for the parameter r< 0.5 there are
+        # 8 attractors close to the origin (radius 0.1)
+        # For r > 0.5 there are 8 attractors very close to the origin (radius 0.01
+        # and 8 attractors far away and well separated.
+        if r < 0.5
+            rr = 0.1
+        else
+            if rr > 1
+                rr = 3
+            else
+                rr = 0.01
+            end
         end
 
-        for (i, p) in enumerate(ps)
-            γ = p[3]
-            fs = fractions_curves[i]
-            attractors = attractors_info[i]
-            k = sort!(collect(keys(fs)))
-            @test maximum(k) ≤ 3
-            attk = sort!(collect(keys(attractors)))
-            @test k == attk
-            @test all(fk -> fk ∈ k, twokeys)
+        if 0 < θ ≤ π/4
+           x = rr*cos(π/8); y = rr*sin(π/8)
+        elseif π/4 < θ ≤ π/2
+            x = rr*cos(3π/8); y = rr*sin(3π/8)
+        elseif π/2 < θ ≤ 3π/4
+            x = rr*cos(5π/8); y = rr*sin(5π/8)
+        elseif 3π/4 < θ ≤ π
+            x = rr*cos(7π/8); y = rr*sin(7π/8)
+        elseif π < θ ≤ 5π/4
+            x = rr*cos(9π/8); y = rr*sin(9π/8)
+        elseif 5π/4 < θ ≤ 6π/4
+            x = rr*cos(11π/8); y = rr*sin(11π/8)
+        elseif 6π/4 < θ ≤ 7π/4
+            x = rr*cos(13π/8); y = rr*sin(13π/8)
+        elseif 7π/4 < θ ≤ 8π/4
+            x = rr*cos(15π/8); y = rr*sin(15π/8)
+        end
+        dz[1]= x; dz[2] = y
+        return
+    end
 
-            # It is arbitrary what id we get, because the third
-            # fixed point that vanishes could have any of the three ids
-            # But we can test for sure how many ids we have
-            # (depending on where we come from we find the attractor for longer)
-            if γ < 0.2
-                @test length(k) == 2
-            elseif γ > 0.24
-                @test length(k) == 3
+    function test_fs(fractions_curves, rrange, frac_results)
+        # For Grouping There should be one cluster for r < 0.5 and then 9 groups of attractors
+        # For matching, all attractors are detected and matched
+        # for r < 0.5 there are 4 attractors and then 12
+        for (i, r) in enumerate(rrange)
+            fs = fractions_curves[i]
+            if r < 0.5
+                k = sort!(collect(keys(fs)))
+                @test length(k) == frac_results[1]
             else
-                # There is a bit of varaibility of exactly when the transition
-                # occurs, and also depends on randomness for when we get exactly 0
-                # fraction for one of the attractors
-                @test length(k) ∈ (2, 3)
+                k = sort!(collect(keys(fs)))
+                @test length(k) == frac_results[2]
             end
             @test sum(values(fs)) ≈ 1
         end
-        # # Plot code for fractions
-        # using GLMakie
-        # x = [fs[finalkeys[1]] for fs in fractions_curves]
-        # y = [fs[finalkeys[2]] for fs in fractions_curves]
-        # z = zeros(length(x))
-        # fig = Figure(resolution = (400, 300))
-        # ax = Axis(fig[1,1])
-        # display(fig)
-        # γs = [p[3] for p in ps]
-        # band!(ax, γs, z, x; color = Cycled(1), label = "1")
-        # band!(ax, γs, x, x .+ y; color = Cycled(2), label  = "2")
-        # band!(ax, γs, x .+ y, 1; color = Cycled(3), label = "3")
-        # xlims!(ax, 0, 1)
-        # ylims!(ax, 0, 1)
-        # ax.ylabel = "fractions"
-        # ax.xlabel = "magnet strength"
-        # axislegend(ax)
-        # Makie.save("magnetic_fracs.png", fig; px_per_unit = 4)
     end
+
+    r = 0.3
+    ds = DeterministicIteratedMap(dumb_map, [0.0, 0.0], [r])
+    yg = xg = range(-10., 10, length = 100)
+    grid = (xg, yg)
+
+    sampler, = statespace_sampler(Random.MersenneTwister(1234);
+        min_bounds = minimum.(grid), max_bounds = maximum.(grid))
+
+    rrange = range(0, 2; length = 21)
+    ridx = 1
+    # First, test the normal function of finding attractors
+    mapper = AttractorsViaRecurrences(ds, grid; sparse = true, show_progress = false)
+    rsc = RecurrencesSeededContinuation(mapper; threshold = 0.1)
+    fractions_curves, attractors_info = continuation(
+        rsc, rrange, ridx, sampler;
+        show_progress = false, samples_per_parameter = 1000,
+    )
+    test_fs(fractions_curves, rrange, [4, 12])
+    # Then, test the aggregation of features via featurizing and histogram
+    using Statistics
+    featurizer = (x) -> mean(x)
+
+    hconfig = GroupViaHistogram(
+        FixedRectangularBinning(range(-4, 4; step = 0.005), 2)
+    )
+
+    aggr_fracs, aggr_info = aggregate_attractor_fractions(
+        fractions_curves, attractors_info, featurizer, hconfig
+    )
+    test_fs(aggr_fracs, rrange, [4, 12])
+
+    # Lastly, test the rather special case of clustering, using the distance
+    # matrix of the actual attractors
+    featurizer = identity
+    info_extraction = identity
+    clust_distance_metric = set_distance
+    cconfig = GroupViaClustering(;
+        clust_distance_metric,
+        rescale_features = false,
+        optimal_radius_method = 0.1,
+    )
+    aggr_fracs, aggr_info = aggregate_attractor_fractions(
+        fractions_curves, attractors_info, featurizer, cconfig, info_extraction
+    )
+    test_fs(aggr_fracs, rrange, [1, 9])
+
 end
 
 if DO_EXTENSIVE_TESTS
@@ -176,7 +263,8 @@ end
 
 @testset "non-found attractors" begin
     # This is standard henon map
-    ds = Systems.henon(; b = 0.3, a = 1.4)
+    henon_rule(x, p, n) = SVector{2}(1.0 - p[1]*x[1]^2 + x[2], p[2]*x[1])
+    ds = DeterministicIteratedMap(henon_rule, zeros(2), [1.4, 0.3])
     ps = range(1.2, 1.25; length = 3)
     # This grid is chosen such that no attractors are in there!
     xg = yg = range(-25, -5; length = 500)
@@ -194,62 +282,85 @@ end
 end
 
 
-@testset "dumb bistable map" begin
-    # This is a fake bistable map that has two equilibrium points
-    # for r > 0.5. It has predictable fractions.
-    function dumb_map(dz, z, p, n)
-        x,y = z
-        r = p[1]
+@testset "magnetic pendulum" begin
+    d, α, ω = 0.3, 0.2, 0.5
+    ds = Systems.magnetic_pendulum(; d, α, ω)
+    xg = yg = range(-3, 3; length = 101)
+    ds = ProjectedDynamicalSystem(ds, 1:2, [0.0, 0.0])
+    mapper = AttractorsViaRecurrences(ds, (xg, yg); Δt = 1.0)
+    rr = range(1, 0; length = 101)
+    psorig = [[1, 1, γ] for γ in rr]
+    pidx = :γs
+    # important to make a sampler that respects the symmetry of the system
+    sampler, isinside = statespace_sampler(Xoshiro(1234); spheredims = 2, radius = 3.0)
+    for (j, ps) in enumerate((psorig, reverse(psorig)))
+        # test that both finding and removing attractor works
+        mapper = AttractorsViaRecurrences(ds, (xg, yg); sparse=false, Δt = 1.0)
 
-        if r < 0.5
-            dz[1] = dz[2] = 0.0
-        else
-            if x > 0
-                dz[1] = r
-                dz[2] = r
+        continuation = RecurrencesSeededContinuation(mapper; threshold = Inf)
+        # With this threshold all attractors are mapped to each other, they are within
+        # distance 1 in state space.
+        fractions_curves, attractors_info = continuation(
+            continuation, ps, pidx, sampler; show_progress = false, samples_per_parameter = 1000
+        )
+
+        # Keys of the two attractors that always exist
+        twokeys = collect(keys(fractions_curves[(j == 2 ? 1 : 101)]))
+
+        @testset "symmetry respect" begin
+            # Initially fractions are all 0.33 but at the end only two of 0.5 remain
+            # because only two attractors remain (with equal magnetic pull)
+            startfracs, endfracs = j == 1 ? [0.33, 0.5] : [0.5, 0.33]
+            @test all(v -> isapprox(v, startfracs; atol = 1e-1), values(fractions_curves[1]))
+            @test all(v -> isapprox(v, endfracs; atol = 1e-1), values(fractions_curves[end]))
+        end
+
+        for (i, p) in enumerate(ps)
+            γ = p[3]
+            fs = fractions_curves[i]
+            attractors = attractors_info[i]
+            k = sort!(collect(keys(fs)))
+            @test maximum(k) ≤ 3
+            attk = sort!(collect(keys(attractors)))
+            @test k == attk
+            @test all(fk -> fk ∈ k, twokeys)
+
+            # It is arbitrary what id we get, because the third
+            # fixed point that vanishes could have any of the three ids
+            # But we can test for sure how many ids we have
+            # (depending on where we come from we find the attractor for longer)
+            if γ < 0.2
+                @test length(k) == 2
+            elseif γ > 0.24
+                @test length(k) == 3
             else
-                dz[1] = -r
-                dz[2] = -r
+                # There is a bit of varaibility of exactly when the transition
+                # occurs, and also depends on randomness for when we get exactly 0
+                # fraction for one of the attractors
+                @test length(k) ∈ (2, 3)
             end
+            @test sum(values(fs)) ≈ 1
         end
-        return
+        # # Plot code for fractions
+        # using GLMakie
+        # x = [fs[finalkeys[1]] for fs in fractions_curves]
+        # y = [fs[finalkeys[2]] for fs in fractions_curves]
+        # z = zeros(length(x))
+        # fig = Figure(resolution = (400, 300))
+        # ax = Axis(fig[1,1])
+        # display(fig)
+        # γs = [p[3] for p in ps]
+        # band!(ax, γs, z, x; color = Cycled(1), label = "1")
+        # band!(ax, γs, x, x .+ y; color = Cycled(2), label  = "2")
+        # band!(ax, γs, x .+ y, 1; color = Cycled(3), label = "3")
+        # xlims!(ax, 0, 1)
+        # ylims!(ax, 0, 1)
+        # ax.ylabel = "fractions"
+        # ax.xlabel = "magnet strength"
+        # axislegend(ax)
+        # Makie.save("magnetic_fracs.png", fig; px_per_unit = 4)
     end
-
-
-    r = 1.
-    ds = DiscreteDynamicalSystem(dumb_map, [0., 0.], [r])
-    yg = xg = range(-10., 10, length = 100)
-    grid = (xg,yg)
-    mapper = Attractors.AttractorsViaRecurrences(ds, grid; sparse = true, show_progress = false)
-
-    sampler, = statespace_sampler(Random.MersenneTwister(1234);
-        min_bounds = minimum.(grid), max_bounds = maximum.(grid))
-
-    rrange = range(0., 2; length = 20)
-    ridx = 1
-    continuation = Attractors.RecurrencesSeededContinuation(mapper; threshold = 0.3)
-    fractions_curves, a = Attractors.continuation(
-        continuation, rrange, ridx, sampler;
-        show_progress = false, samples_per_parameter = 1000
-    )
-
-    for (i, r) in enumerate(rrange)
-
-        fs = fractions_curves[i]
-        if r < 0.5
-            k = sort!(collect(keys(fs)))
-            @test length(k) == 1
-        else
-            k = sort!(collect(keys(fs)))
-            @test length(k) == 2
-            v = values(fs)
-            for f in v
-                @test (0.4 < f < 0.6)
-            end
-        end
-        @test sum(values(fs)) ≈ 1
-    end
-
 end
 
 end
+

--- a/test/continuation/recurrences_continuation.jl
+++ b/test/continuation/recurrences_continuation.jl
@@ -24,7 +24,7 @@ using Random
         continuation = RecurrencesSeedingContinuation(mapper; threshold = Inf)
         # With this threshold all attractors are mapped to each other, they are within
         # distance 1 in state space.
-        fractions_curves, attractors_info = basins_fractions_continuation(
+        fractions_curves, attractors_info = continuation(
             continuation, ps, pidx, sampler; show_progress = false, samples_per_parameter = 1000
         )
 
@@ -121,7 +121,7 @@ if DO_EXTENSIVE_TESTS
         threshold = 0.99, method = distance_function
     )
     ps = psorig
-    fractions_curves, attractors_info = basins_fractions_continuation(
+    fractions_curves, attractors_info = continuation(
         continuation, ps, pidx, sampler;
         show_progress = false, samples_per_parameter = 100
     )
@@ -186,7 +186,7 @@ end
     )
     mapper = AttractorsViaRecurrences(ds, (xg, yg); sparse=false)
     continuation = RecurrencesSeedingContinuation(mapper)
-    fractions_curves, attractors_info = basins_fractions_continuation(
+    fractions_curves, attractors_info = continuation(
         continuation, ps, pidx, sampler;
         show_progress = false, samples_per_parameter = 100
     )
@@ -228,7 +228,7 @@ end
     rrange = range(0., 2; length = 20)
     ridx = 1
     continuation = Attractors.RecurrencesSeedingContinuation(mapper; threshold = 0.3)
-    fractions_curves, a = Attractors.basins_fractions_continuation(
+    fractions_curves, a = Attractors.continuation(
         continuation, rrange, ridx, sampler;
         show_progress = false, samples_per_parameter = 1000
     )


### PR DESCRIPTION
@awage have a look. This is how you can still use DBSCAN directly on attractors with this interface without having to unify anything or introduce additional keywords or structs about how to match.