### PR TITLE
Always return attractors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.1
+- `basins_fractions` with a mapper will always return attractors.
+
+# v1
+- Added the `continuation` function and the two types `RecurrencesSeededContinuation` and `GroupAcrossParametersContinuation`
+
 # v0.1.0
 This is the first release. It continues from ChaosTools.jl v2.9, and hence, the comparison of attractor-related features is w.r.t to that version.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v1.1
-- `basins_fractions` with a mapper will always return attractors.
+
+- `basins_fractions` no longer returns the attractors. Instead, a function `extract_attractors(mapper::AttractorMapper)` is provided that gives the attractors. This makes an overall more convenient experience that doesn't depend on the type of the initial conditions used.
 
 # v1
 - Added the `continuation` function and the two types `RecurrencesSeededContinuation` and `GroupAcrossParametersContinuation`

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Attractors"
 uuid = "f3fd9213-ca85-4dba-9dfd-7fc91308fec7"
 authors = ["George Datseris <datseris.george@gmail.com>", "Kalel Rossi", "Alexandre Wagemakers"]
 repo = "https://github.com/JuliaDynamics/Attractors.jl.git"
-version = "1.0.1"
+version = "1.1.0"
 
 [deps]
 Clustering = "aaaa29a8-35af-508c-8bc3-b662a17a0fe5"

--- a/docs/src/basins.md
+++ b/docs/src/basins.md
@@ -9,6 +9,7 @@ Calculating basins of attraction, or their state space fractions, can be done wi
 
 ```@docs
 basins_fractions
+extract_attractors
 basins_of_attraction
 statespace_sampler
 ```

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -50,6 +50,26 @@ scatter_attractors!(ax, attractors)
 fig
 ```
 
+We could get only the fractions of the basins of attractions using [`basins_fractions`](@ref), which is typically the more useful thing to do in a high dimensional system.
+In such cases it is also typically more useful to define a sampler that generates initial conditions on the fly instead of pre-defining some initial conditions (as is done in [`basins_of_attraction`](@ref). This is simple to do:
+
+```@example MAIN
+grid = (xg, yg)
+mapper = AttractorsViaRecurrences(ds, grid;
+    sparse = false, mx_chk_lost = 1000
+)
+
+sampler, = statespace_sampler(;
+    min_bounds = minimum.(grid), max_bounds = maximum.(grid)
+)
+
+basins = basins_fractions(mapper, sampler)
+```
+
+in this case, to also get the attractors we simply extract them from the underlying storage of the mapper:
+```@example MAIN
+attractors = extract_attractors(mapper)
+```
 
 ## Fractality of 2D basins of the (4D) magnetic pendulum
 In this section we will calculate the basins of attraction of the four-dimensional magnetic pendulum. We know that the attractors of this system are all individual fixed points on the (x, y) plane so we will only compute the basins there. We can also use this opportunity to highlight a different method, the [`AttractorsViaProximity`](@ref) which works when we already know where the attractors are. Furthermore we will also use a `projected_integrator` to project the 4D system onto a 2D plane, saving a lot of computational time!

--- a/src/continuation/continuation_recurrences.jl
+++ b/src/continuation/continuation_recurrences.jl
@@ -89,7 +89,7 @@ function continuation(
     reset!(mapper)
     # first parameter is run in isolation, as it has no prior to seed from
     set_parameter!(mapper.ds, pidx, prange[1])
-    fs = basins_fractions(mapper, ics; show_progress = false, N = samples_per_parameter)
+    fs = basins_fractions(mapper, ics; show_progress = false, N = samples_per_parameter)[1]
     # At each parmaeter `p`, a dictionary mapping attractor ID to fraction is created.
     fractions_curves = [fs]
     # Furthermore some info about the attractors is stored and returned
@@ -124,7 +124,7 @@ function continuation(
         # Now perform basin fractions estimation as normal, utilizing found attractors
         fs = basins_fractions(mapper, ics;
             additional_fs = seeded_fs, show_progress = false, N = samples_per_parameter
-        )
+        )[1]
         current_attractors = mapper.bsn_nfo.attractors
         if !isempty(current_attractors) && !isempty(prev_attractors)
             # If there are any attractors,

--- a/src/continuation/continuation_recurrences.jl
+++ b/src/continuation/continuation_recurrences.jl
@@ -89,7 +89,7 @@ function continuation(
     reset!(mapper)
     # first parameter is run in isolation, as it has no prior to seed from
     set_parameter!(mapper.ds, pidx, prange[1])
-    fs = basins_fractions(mapper, ics; show_progress = false, N = samples_per_parameter)[1]
+    fs = basins_fractions(mapper, ics; show_progress = false, N = samples_per_parameter)
     # At each parmaeter `p`, a dictionary mapping attractor ID to fraction is created.
     fractions_curves = [fs]
     # Furthermore some info about the attractors is stored and returned
@@ -124,7 +124,7 @@ function continuation(
         # Now perform basin fractions estimation as normal, utilizing found attractors
         fs = basins_fractions(mapper, ics;
             additional_fs = seeded_fs, show_progress = false, N = samples_per_parameter
-        )[1]
+        )
         current_attractors = mapper.bsn_nfo.attractors
         if !isempty(current_attractors) && !isempty(prev_attractors)
             # If there are any attractors,

--- a/src/mapping/attractor_mapping.jl
+++ b/src/mapping/attractor_mapping.jl
@@ -116,7 +116,7 @@ function basins_fractions(mapper::AttractorMapper, ics::Union{AbstractStateSpace
     # Transform count into fraction
     ffs = Dict(k => v/N for (k, v) in fs)
     if used_StateSpaceSet
-        attractors = extract_attractors(mapper, labels, ics)
+        attractors = extract_attractors(mapper)
         return ffs, labels, attractors
     else
         return ffs

--- a/src/mapping/attractor_mapping.jl
+++ b/src/mapping/attractor_mapping.jl
@@ -115,11 +115,11 @@ function basins_fractions(mapper::AttractorMapper, ics::Union{AbstractStateSpace
     N = N + (isempty(additional_fs) ? 0 : sum(values(additional_fs)))
     # Transform count into fraction
     ffs = Dict(k => v/N for (k, v) in fs)
+    attractors = extract_attractors(mapper)
     if used_StateSpaceSet
-        attractors = extract_attractors(mapper)
-        return ffs, labels, attractors
+        return ffs, attractors
     else
-        return ffs
+        return ffs, attractors, labels
     end
 end
 

--- a/src/mapping/attractor_mapping.jl
+++ b/src/mapping/attractor_mapping.jl
@@ -53,7 +53,11 @@ Base.show(io::IO, mapper::AttractorMapper) = generic_mapper_print(io, mapper)
 #########################################################################################
 # It works for all mappers that define the function-like-object behavior
 """
-    basins_fractions(mapper::AttractorMapper, ics::Union{StateSpaceSet, Function}; kwargs...)
+    basins_fractions(
+        mapper::AttractorMapper,
+        ics::Union{StateSpaceSet, Function};
+        kwargs...
+    )
 
 Approximate the state space fractions `fs` of the basins of attraction of a dynamical
 stystem by mapping initial conditions to attractors using `mapper`
@@ -67,15 +71,19 @@ Initial conditions to use are defined by `ics`. It can be:
   Then `N` random initial conditions are chosen.
   See [`statespace_sampler`](@ref) to generate such functions.
 
-The returned arguments are `fs`.
-If `ics` is a `StateSpaceSet` then the `labels` of each initial condition and roughly approximated
-attractors are also returned: `fs, labels, attractors`.
+## Return
 
-The output `fs` is a dictionary whose keys are the labels given to each attractor
-(always integers enumerating the different attractors), and the
-values are their respective fractions. The label `-1` is given to any initial condition
-where `mapper` could not match to an attractor (this depends on the `mapper` type).
-`attractors` has the same structure, mapping labels to `StateSpaceSet`s.
+The function will always return the two values `fractions, attractors`,
+and, if `ics` is a `StateSpaceSet`, it will also return a third value `labels`, where:
+
+- `fractions` a dictionary whose keys are the labels given to each attractor
+  (always integers enumerating the different attractors), and whose
+  values are the respective basins fractions. The label `-1` is given to any initial condition
+  where `mapper` could not match to an attractor (this depends on the `mapper` type).
+- `attractors` has the same structure as `fractions`, mapping labels to `StateSpaceSet`s
+  (which are the found attractors or a representation of them)
+- `labels` is a _vector_, of equal length to `ics`, that contains the label each initial
+  condition was mapped to.
 
 See [`AttractorMapper`](@ref) for all possible `mapper` types.
 

--- a/src/mapping/attractor_mapping.jl
+++ b/src/mapping/attractor_mapping.jl
@@ -8,7 +8,8 @@ export AttractorMapper,
     ClusteringConfig,
     basins_fractions,
     basins_of_attraction,
-    automatic_Δt_basins
+    automatic_Δt_basins,
+    extract_attractors
 
 #########################################################################################
 # AttractorMapper structure definition
@@ -131,7 +132,9 @@ Return a dictionary mapping label IDs to attractors found by the `mapper`.
 This function should be called after calling [`basins_fractions`](@ref)
 with the given `mapper` so that the attractors have actually been found first.
 
-# TODO: Write about clustering method.
+For `AttractorsViaFeaturizing`, the attractors are only stored if
+the mapper was called with pre-defined initial conditions rather than
+a sampler (function returning initial conditions).
 """
 extract_attractors(::AttractorMapper) = error("not imlemented")
 

--- a/src/mapping/attractor_mapping.jl
+++ b/src/mapping/attractor_mapping.jl
@@ -110,16 +110,16 @@ function basins_fractions(mapper::AttractorMapper, ics::Union{AbstractStateSpace
         used_StateSpaceSet && (labels[i] = label)
         show_progress && ProgressMeter.next!(progress)
     end
-    # the non-public-API `additional_fs` is used in the continuation methods
+    # the non-public-API `additional_fs` i s used in the continuation methods
     additive_dict_merge!(fs, additional_fs)
     N = N + (isempty(additional_fs) ? 0 : sum(values(additional_fs)))
     # Transform count into fraction
     ffs = Dict(k => v/N for (k, v) in fs)
     attractors = extract_attractors(mapper)
     if used_StateSpaceSet
-        return ffs, attractors
-    else
         return ffs, attractors, labels
+    else
+        return ffs, attractors
     end
 end
 
@@ -155,7 +155,7 @@ function basins_of_attraction(mapper::AttractorMapper, grid::Tuple; kwargs...)
     basins = zeros(Int32, map(length, grid))
     I = CartesianIndices(basins)
     A = StateSpaceSet([generate_ic_on_grid(grid, i) for i in vec(I)])
-    fs, labels, attractors = basins_fractions(mapper, A; kwargs...)
+    fs, attractors, labels = basins_fractions(mapper, A; kwargs...)
     vec(basins) .= vec(labels)
     return basins, attractors
 end

--- a/src/mapping/attractor_mapping.jl
+++ b/src/mapping/attractor_mapping.jl
@@ -163,7 +163,8 @@ function basins_of_attraction(mapper::AttractorMapper, grid::Tuple; kwargs...)
     basins = zeros(Int32, map(length, grid))
     I = CartesianIndices(basins)
     A = StateSpaceSet([generate_ic_on_grid(grid, i) for i in vec(I)])
-    fs, attractors, labels = basins_fractions(mapper, A; kwargs...)
+    fs, labels = basins_fractions(mapper, A; kwargs...)
+    attractors = extract_attractors(mapper)
     vec(basins) .= vec(labels)
     return basins, attractors
 end

--- a/src/mapping/attractor_mapping_featurizing.jl
+++ b/src/mapping/attractor_mapping_featurizing.jl
@@ -8,7 +8,7 @@ export AttractorsViaFeaturizing, extract_features
 #####################################################################################
 include("grouping/all_grouping_configs.jl")
 
-struct AttractorsViaFeaturizing{DS<:DynamicalSystem, G<:GroupingConfig, T, F, U} <: AttractorMapper
+struct AttractorsViaFeaturizing{DS<:DynamicalSystem, G<:GroupingConfig, F, T} <: AttractorMapper
     ds::DS
     featurizer::F
     group_config::G

--- a/src/mapping/attractor_mapping_featurizing.jl
+++ b/src/mapping/attractor_mapping_featurizing.jl
@@ -104,11 +104,12 @@ function basins_fractions(mapper::AttractorsViaFeaturizing, ics::ValidICS;
     features = extract_features(mapper, ics; show_progress, N)
     group_labels = group_features(features, mapper.group_config)
     fs = basins_fractions(group_labels) # Vanilla fractions method with Array input
-    attractors = extract_attractors(mapper, group_labels, ics)
     if typeof(ics) <: AbstractStateSpaceSet
-        return fs, attractors, group_labels
+        # TODO: Store attractors
+        attractors = extract_attractors(mapper, group_labels, ics)
+        return fs, group_labels
     else
-        return fs, attractors
+        return fs
     end
 end
 

--- a/src/mapping/attractor_mapping_featurizing.jl
+++ b/src/mapping/attractor_mapping_featurizing.jl
@@ -8,7 +8,7 @@ export AttractorsViaFeaturizing, extract_features
 #####################################################################################
 include("grouping/all_grouping_configs.jl")
 
-struct AttractorsViaFeaturizing{DS<:DynamicalSystem, G<:GroupingConfig, T, F} <: AttractorMapper
+struct AttractorsViaFeaturizing{DS<:DynamicalSystem, G<:GroupingConfig, T, F, U} <: AttractorMapper
     ds::DS
     featurizer::F
     group_config::G
@@ -70,8 +70,8 @@ in contrast to [`AttractorsViaRecurrences`](@ref).
     [New J. Phys.22 03303](http://dx.doi.org/10.1088/1367-2630/ab7a05)
 """
 function AttractorsViaFeaturizing(ds::DynamicalSystem, featurizer::Function,
-    group_config::GroupingConfig = ClusteringGrouping();
-    T=100, Ttr=100, Δt=1, threaded = true,
+        group_config::GroupingConfig = ClusteringGrouping();
+        T=100, Ttr=100, Δt=1, threaded = true,
     )
     # For parallelization, the dynamical system is deepcopied.
     return AttractorsViaFeaturizing(
@@ -168,14 +168,12 @@ function extract_features_threaded(mapper, ics; show_progress = true, N = 1000)
 end
 
 function extract_feature(ds::DynamicalSystem, u0::AbstractVector{<:Real}, mapper)
-    # Notice that this uses the low-level interface of `trajectory` that works
-    # given an integrator. In DynamicalSystems 3.0 this will a part of the API
     A, t = trajectory(ds, mapper.total, u0; Ttr = mapper.Ttr, Δt = mapper.Δt)
     return mapper.featurizer(A, t)
 end
 
 function extract_attractors(mapper::AttractorsViaFeaturizing, labels, ics)
-    uidxs = unique(labels)
+    uidxs = unique(i -> labels[i], eachindex(labels))
     return Dict(labels[i] => trajectory(mapper.ds, mapper.total, ics[i];
     Ttr = mapper.Ttr, Δt = mapper.Δt) for i in uidxs if i ≠ -1)
 end

--- a/src/mapping/attractor_mapping_featurizing.jl
+++ b/src/mapping/attractor_mapping_featurizing.jl
@@ -75,10 +75,10 @@ function AttractorsViaFeaturizing(ds::DynamicalSystem, featurizer::Function,
         T=100, Ttr=100, Δt=1, threaded = true,
     )
     D = dimension(ds)
-    T = eltype(current_state(ds))
+    V = eltype(current_state(ds))
     # For parallelization, the dynamical system is deepcopied.
     return AttractorsViaFeaturizing(
-        ds, featurizer, group_config, Ttr, Δt, T, threaded, Dict{Int, StateSpaceSet{D,T}}(),
+        ds, featurizer, group_config, Ttr, Δt, T, threaded, Dict{Int, StateSpaceSet{D,V}}(),
     )
 end
 
@@ -181,7 +181,7 @@ end
 function extract_attractors(mapper::AttractorsViaFeaturizing, labels, ics)
     uidxs = unique(i -> labels[i], eachindex(labels))
     return Dict(labels[i] => trajectory(mapper.ds, mapper.total, ics[i];
-    Ttr = mapper.Ttr, Δt = mapper.Δt) for i in uidxs if i ≠ -1)
+    Ttr = mapper.Ttr, Δt = mapper.Δt)[1] for i in uidxs if i ≠ -1)
 end
 
 extract_attractors(mapper::AttractorsViaFeaturizing) = mapper.attractors

--- a/src/mapping/attractor_mapping_featurizing.jl
+++ b/src/mapping/attractor_mapping_featurizing.jl
@@ -102,13 +102,13 @@ function basins_fractions(mapper::AttractorsViaFeaturizing, ics::ValidICS;
         show_progress = true, N = 1000
     )
     features = extract_features(mapper, ics; show_progress, N)
-    cluster_labels  = group_features(features, mapper.group_config)
-    fs = basins_fractions(cluster_labels) # Vanilla fractions method with Array input
+    group_labels = group_features(features, mapper.group_config)
+    fs = basins_fractions(group_labels) # Vanilla fractions method with Array input
+    attractors = extract_attractors(mapper, group_labels, ics)
     if typeof(ics) <: AbstractStateSpaceSet
-        attractors = extract_attractors(mapper, cluster_labels, ics)
-        return fs, cluster_labels, attractors
+        return fs, attractors, group_labels
     else
-        return fs
+        return fs, attractors
     end
 end
 
@@ -175,7 +175,7 @@ function extract_feature(ds::DynamicalSystem, u0::AbstractVector{<:Real}, mapper
 end
 
 function extract_attractors(mapper::AttractorsViaFeaturizing, labels, ics)
-    uidxs = unique(i -> labels[i], 1:length(labels))
+    uidxs = unique(labels)
     return Dict(labels[i] => trajectory(mapper.ds, mapper.total, ics[i];
     Ttr = mapper.Ttr, Δt = mapper.Δt) for i in uidxs if i ≠ -1)
 end

--- a/src/mapping/attractor_mapping_proximity.jl
+++ b/src/mapping/attractor_mapping_proximity.jl
@@ -139,4 +139,4 @@ function Base.show(io::IO, mapper::AttractorsViaProximity)
     return
 end
 
-extract_attractors(mapper::AttractorsViaProximity, labels, ics) = mapper.attractors
+extract_attractors(mapper::AttractorsViaProximity) = mapper.attractors

--- a/src/mapping/attractor_mapping_recurrences.jl
+++ b/src/mapping/attractor_mapping_recurrences.jl
@@ -129,7 +129,7 @@ function Base.show(io::IO, mapper::AttractorsViaRecurrences)
     return
 end
 
-extract_attractors(m::AttractorsViaRecurrences, labels, ics) = m.bsn_nfo.attractors
+extract_attractors(m::AttractorsViaRecurrences) = m.bsn_nfo.attractors
 
 """
     basins_of_attraction(mapper::AttractorsViaRecurrences; show_progress = true)

--- a/test/mapping/attractor_mapping.jl
+++ b/test/mapping/attractor_mapping.jl
@@ -49,7 +49,7 @@ function test_basins(ds, u0s, grid, expected_fs_raw, featurizer;
         @test sum(values(fs)) ≈ 1 atol=1e-14
 
         # Precise test with known initial conditions
-        fs, labels, approx_atts = basins_fractions(mapper, ics; show_progress = false)[1]
+        fs, approx_atts, labels = basins_fractions(mapper, ics; show_progress = false)
         found_fs = sort(collect(values(fs)))
         if length(found_fs) > length(expected_fs)
             # drop -1 key if it corresponds to just unidentified points

--- a/test/mapping/attractor_mapping.jl
+++ b/test/mapping/attractor_mapping.jl
@@ -42,14 +42,15 @@ function test_basins(ds, u0s, grid, expected_fs_raw, featurizer;
             end
         end
         # Generic test
-        fs = basins_fractions(mapper, sampler; show_progress = false)[1]
+        fs = basins_fractions(mapper, sampler; show_progress = false)
         for k in keys(fs)
             @test 0 ≤ fs[k] ≤ 1
         end
         @test sum(values(fs)) ≈ 1 atol=1e-14
 
         # Precise test with known initial conditions
-        fs, approx_atts, labels = basins_fractions(mapper, ics; show_progress = false)
+        fs, labels = basins_fractions(mapper, ics; show_progress = false)
+        approx_atts = extract_attractors(mapper)
         found_fs = sort(collect(values(fs)))
         if length(found_fs) > length(expected_fs)
             # drop -1 key if it corresponds to just unidentified points

--- a/test/mapping/attractor_mapping.jl
+++ b/test/mapping/attractor_mapping.jl
@@ -42,14 +42,14 @@ function test_basins(ds, u0s, grid, expected_fs_raw, featurizer;
             end
         end
         # Generic test
-        fs = basins_fractions(mapper, sampler; show_progress = false)
+        fs = basins_fractions(mapper, sampler; show_progress = false)[1]
         for k in keys(fs)
             @test 0 ≤ fs[k] ≤ 1
         end
         @test sum(values(fs)) ≈ 1 atol=1e-14
 
         # Precise test with known initial conditions
-        fs, labels, approx_atts = basins_fractions(mapper, ics; show_progress = false)
+        fs, labels, approx_atts = basins_fractions(mapper, ics; show_progress = false)[1]
         found_fs = sort(collect(values(fs)))
         if length(found_fs) > length(expected_fs)
             # drop -1 key if it corresponds to just unidentified points

--- a/test/mapping/histogram_grouping.jl
+++ b/test/mapping/histogram_grouping.jl
@@ -32,7 +32,7 @@ min_bounds = minimum.(grid), max_bounds = maximum.(grid)
 )
 ics = StateSpaceSet([sampler() for i in 1:1000])
 
-fs, approx_atts, labels = basins_fractions(mapper, ics; show_progress = false)
+fs, = basins_fractions(mapper, ics; show_progress = false)
 @test length(keys(fs)) == 2
 @test fs[1] ≈ 0.451 rtol = 1e-2
 # the divergent points go to last bin, which is 25 = 5x5

--- a/test/mapping/histogram_grouping.jl
+++ b/test/mapping/histogram_grouping.jl
@@ -32,7 +32,7 @@ min_bounds = minimum.(grid), max_bounds = maximum.(grid)
 )
 ics = StateSpaceSet([sampler() for i in 1:1000])
 
-fs, labels, approx_atts = basins_fractions(mapper, ics; show_progress = false)
+fs, approx_atts, labels = basins_fractions(mapper, ics; show_progress = false)
 @test length(keys(fs)) == 2
 @test fs[1] ≈ 0.451 rtol = 1e-2
 # the divergent points go to last bin, which is 25 = 5x5

--- a/test/mapping/recurrence.jl
+++ b/test/mapping/recurrence.jl
@@ -45,7 +45,7 @@ using Random
             min_bounds = [-0.5, 0], max_bounds = [0.5, 1])
         ics = StateSpaceSet([sampler() for i in 1:1000])
 
-        fs, labels, atts = basins_fractions(mapper, ics; show_progress=false)
+        fs, atts, labels = basins_fractions(mapper, ics; show_progress=false)
         num_att = length(atts)
         return num_att
     end
@@ -70,10 +70,10 @@ end
             ics = StateSpaceSet([sampler() for i in 1:1000])
 
             mapper = AttractorsViaRecurrences(ds, grid; sparse=true, show_progress = false, kwargs...)
-            fs_sparse, labels_sparse, approx_atts_sparse = basins_fractions(mapper, ics; show_progress = false)
+            fs_sparse, approx_atts_sparse, labels_sparse = basins_fractions(mapper, ics; show_progress = false)
 
             mapper = AttractorsViaRecurrences(ds, grid; sparse=false, show_progress = false, kwargs...)
-            fs_non, labels_non, approx_atts_non = basins_fractions(mapper, ics; show_progress = false)
+            fs_non, approx_atts_non, labels_non = basins_fractions(mapper, ics; show_progress = false)
 
             @test fs_sparse == fs_non
             @test labels_sparse == labels_non


### PR DESCRIPTION
I am preparing a tutorial on Attractors.jl and I found itr very annoying that `basins_fractions` won't return the attractors if a sampler is given. This is changed here so that attractors are always returned.

Technically this is a brteaking change, but I Am assuming this package doesn't have a user base yet so I'll go ahead with it...