### PR TITLE
Allow `Dt` instead of `Δt` in recurrences method

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Attractors"
 uuid = "f3fd9213-ca85-4dba-9dfd-7fc91308fec7"
 authors = ["George Datseris <datseris.george@gmail.com>", "Kalel Rossi", "Alexandre Wagemakers"]
 repo = "https://github.com/JuliaDynamics/Attractors.jl.git"
-version = "1.2.5"
+version = "1.2.6"
 
 [deps]
 Clustering = "aaaa29a8-35af-508c-8bc3-b662a17a0fe5"

--- a/src/mapping/attractor_mapping_recurrences.jl
+++ b/src/mapping/attractor_mapping_recurrences.jl
@@ -28,6 +28,7 @@ dimensional subspace.
 
 * `Ttr = 0`: Skip a transient before the recurrence routine begins.
 * `Δt`: Approximate integration time step (second argument of the `step!` function).
+  The keyword `Dt` can also be used instead if `Δ` (`\\Delta`) is not accessible.
   It is `1` for discrete time systems.
   For continuous systems, an automatic value is calculated using
   [`automatic_Δt_basins`](@ref). For very fine grids, this can become very small,
@@ -35,7 +36,7 @@ dimensional subspace.
   integrators. In such cases, use `force_non_adaptive = true`.
 * `force_non_adaptive = false`: Only used if the input dynamical system is `CoupledODEs`.
   If `true` the additional keywords `adaptive = false, dt = Δt` are given as `diffeq`
-  to the `CoupledODEs`. This means that adaptive integration is turned of and `Δt` is
+  to the `CoupledODEs`. This means that adaptive integration is turned off and `Δt` is
   used as the ODE integrator timestep. This is useful in (1) very fine grids, and (2)
   if some of the attractors are limit cycles. We have noticed that in this case the
   integrator timestep becomes commensurate with the limit cycle period, leading to
@@ -116,7 +117,7 @@ struct AttractorsViaRecurrences{DS<:DynamicalSystem, B, G, K} <: AttractorMapper
 end
 
 function AttractorsViaRecurrences(ds::DynamicalSystem, grid;
-        Δt = nothing, sparse = true, force_non_adaptive = false, kwargs...
+        Dt = nothing, Δt = Dt, sparse = true, force_non_adaptive = false, kwargs...
     )
     bsn_nfo = initialize_basin_info(ds, grid, Δt, sparse)
     if ds isa CoupledODEs && force_non_adaptive


### PR DESCRIPTION
Because latex cant display unicode, because latex is a shity system that is 5 decades behind the rest of the planet.