### PR TITLE
Add `remacth!` function ; do some renames and doc polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - `basins_fractions` no longer returns the attractors. Instead, a function `extract_attractors(mapper::AttractorMapper)` is provided that gives the attractors. This makes an overall more convenient experience that doesn't depend on the type of the initial conditions used.
 
 # v1
-- Added the `continuation` function and the two types `RecurrencesSeededContinuation` and `GroupAcrossParametersContinuation`
+- Added the `continuation` function and the two types `RecurrencesFindAndMatch` and `GroupAcrossParametersContinuation`
 
 # v0.1.0
 This is the first release. It continues from ChaosTools.jl v2.9, and hence, the comparison of attractor-related features is w.r.t to that version.
@@ -28,7 +28,7 @@ This is the first release. It continues from ChaosTools.jl v2.9, and hence, the 
 
 ## Basin fractions continuation
 - New function `continuation` that calculates basins fractions and how these change versus a parameter (given a continuation method)
-- New basins fraction continuation method `RecurrencesSeededContinuation` that utilizes a brand new algorithm to continuate basins fractions of arbitrary systems.
+- New basins fraction continuation method `RecurrencesFindAndMatch` that utilizes a brand new algorithm to continuate basins fractions of arbitrary systems.
 - `match_attractor_ids!` has been fully overhauled to be more flexible, allow more ways to match, and also allow arbitrary user-defined ways to match.
 - New function `match_basins_ids!` for matching the output of basins_of_attraction`.
 - New exported functions `swap_dict_keys!, unique_keys, replacement_map` used in code that matches attractors and could be useful to front-end users.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v1.4
+
+- New function `rematch!` that can be used after `continuation` is called with `AttractorsViaRecurrences`, if the original matching performed was not ideal.
+
+# v1.3
+- More plotting functions have been added and plotting has been exposed as API. After Julia 1.9 it will also be documented and formally included in the built docs.
+
 # v1.2
 - Add option `force_non_adaptive` to `AttractorsViaRecurrences`. This option is of instrumental importance when the grid is too fine or when limit cycle attractors are involved.
 

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Attractors"
 uuid = "f3fd9213-ca85-4dba-9dfd-7fc91308fec7"
 authors = ["George Datseris <datseris.george@gmail.com>", "Kalel Rossi", "Alexandre Wagemakers"]
 repo = "https://github.com/JuliaDynamics/Attractors.jl.git"
-version = "1.3.0"
+version = "1.4.0"
 
 [deps]
 Clustering = "aaaa29a8-35af-508c-8bc3-b662a17a0fe5"

--- a/docs/src/continuation.md
+++ b/docs/src/continuation.md
@@ -18,7 +18,7 @@ continuation
 ## Recurrences continuation (best)
 
 ```@docs
-RecurrencesSeededContinuation
+RecurrencesFindAndMatch
 ```
 
 ## Matching attractors

--- a/docs/src/continuation.md
+++ b/docs/src/continuation.md
@@ -37,5 +37,5 @@ aggregate_attractor_fractions
 
 ## Grouping continuation
 ```@docs
-GroupAcrossParameterContinuation
+GroupAcrossParameter
 ```

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -234,7 +234,7 @@ pidx = :γs
 sampler, = statespace_sampler(Xoshiro(1234); spheredims = 2, radius = 3.0)
 # continue attractors and basins:
 # `Inf` threshold fits here, as attractors move smoothly in parameter space
-rsc = RecurrencesSeededContinuation(mapper; threshold = Inf)
+rsc = RecurrencesFindAndMatch(mapper; threshold = Inf)
 fractions_curves, attractors_info = continuation(
     rsc, prange, pidx, sampler;
     show_progress = false, samples_per_parameter = 100
@@ -279,10 +279,10 @@ as you can see, two of the three fixed points, and their stability, do not depen
 
 ## Extinction of a species in a multistable competition model
 
-In this advanced example we utilize both [`RecurrencesSeededContinuation`](@ref) and [`aggregate_attractor_fractions`](@ref) in analyzing species extinction in a dynamical model of competition between multiple species.
+In this advanced example we utilize both [`RecurrencesFindAndMatch`](@ref) and [`aggregate_attractor_fractions`](@ref) in analyzing species extinction in a dynamical model of competition between multiple species.
 The final goal is to show the percentage of how much of the state space leads to the extinction or not of a pre-determined species, as we vary a parameter. The model however displays extreme multistability, a feature we want to measure and preserve before aggregating information into "extinct or not".
 
-To measure and preserve this we will apply [`RecurrencesSeededContinuation`](@ref) as-is first. Then we can aggregate information. First we have
+To measure and preserve this we will apply [`RecurrencesFindAndMatch`](@ref) as-is first. Then we can aggregate information. First we have
 ```julia
 using Attractors, OrdinaryDiffEq
 using PredefinedDynamicalSystems
@@ -306,7 +306,7 @@ sampler, = statespace_sampler(Xoshiro(1234);
 # initialize mapper
 mapper = AttractorsViaRecurrences(ds, grid; recurrences_kwargs...)
 # perform continuation of attractors and their basins
-continuation = RecurrencesSeededContinuation(mapper; threshold = Inf)
+continuation = RecurrencesFindAndMatch(mapper; threshold = Inf)
 fractions_curves, attractors_info = continuation(
     continuation, prange, pidx, sampler;
     show_progress = true, samples_per_parameter
@@ -319,7 +319,7 @@ Main.basins_curves_plot(fractions_curves, prange; separatorwidth = 1)
 _this example is not actually run when building the docs, because it takes about 60 minutes to complete depending on the computer; we load precomputed results instead_
 
 As you can see, the system has extreme multistability with 64 unique attractors
-(according to the default matching behavior in [`RecurrencesSeededContinuation`](@ref); a stricter matching with less than `Inf` threshold would generate more "distinct" attractors).
+(according to the default matching behavior in [`RecurrencesFindAndMatch`](@ref); a stricter matching with less than `Inf` threshold would generate more "distinct" attractors).
 One could also isolate a specific parameter slice, and do the same as what we do in
 the [Fractality of 2D basins of the (4D) magnetic pendulum](@ref) example, to prove that the basin boundaries are fractal, thereby indeed confirming the paper title "Fundamental Unpredictability".
 

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -415,7 +415,7 @@ mapper = AttractorsViaFeaturizing(
     T = 6, threaded = true, Ttr = 500,
 )
 
-continuation = GroupAcrossParameterContinuation(mapper; par_weight = 1.0)
+continuation = GroupAcrossParameter(mapper; par_weight = 1.0)
 
 ps = range(0.6, 1.1; length = 11)
 pidx = 1

--- a/src/continuation/aggregate_attractor_fractions.jl
+++ b/src/continuation/aggregate_attractor_fractions.jl
@@ -8,7 +8,7 @@ export aggregate_attractor_fractions
 Aggregate the already-estimated curves of fractions of basins of attraction of similar
 attractors using the same pipeline used by [`GroupingConfig`](@ref).
 The most typical application of this function is to transform the output of
-[`RecurrencesSeededContinuation`](@ref) so that similar attractors, even across parameter
+[`RecurrencesFindAndMatch`](@ref) so that similar attractors, even across parameter
 space, are grouped into one "attractor". Thus, the fractions of their basins are aggregated.
 
 You could also use this function to aggregate attractors and their fractions even in
@@ -28,7 +28,7 @@ in [Extinction of a species in a multistable competition model](@ref).
 1. `fractions_curves`: a vector of dictionaries mapping labels to basin fractions.
 2. `attractors_info`: a vector of dictionaries mapping labels to attractors.
    1st and 2nd argument are exactly like the return values of
-   [`continuation`](@ref) with [`RecurrencesSeededContinuation`](@ref)
+   [`continuation`](@ref) with [`RecurrencesFindAndMatch`](@ref)
    (or, they can be the return of [`basins_fractions`](@ref)).
 3. `featurizer`: a 1-argument function to map an attractor into an appropriate feature
    to be grouped later. Features expected by [`GroupingConfig`](@ref) are `SVector`.

--- a/src/continuation/aggregate_attractor_fractions.jl
+++ b/src/continuation/aggregate_attractor_fractions.jl
@@ -34,7 +34,7 @@ in [Extinction of a species in a multistable competition model](@ref).
    to be grouped later. Features expected by [`GroupingConfig`](@ref) are `SVector`.
 4. `group_config`: a subtype of [`GroupingConfig`](@ref).
 5. `info_extraction`: a function accepting a vector of features and returning a description
-   of the features. I.e., exactly as in [`GroupAcrossParameterContinuation`](@ref).
+   of the features. I.e., exactly as in [`GroupAcrossParameter`](@ref).
    The 5th argument is optional and defaults to the centroid of the features.
 
 ## Return

--- a/src/continuation/basins_fractions_continuation_api.jl
+++ b/src/continuation/basins_fractions_continuation_api.jl
@@ -28,7 +28,7 @@ the dynamical system (as in [`basins_fractions`](@ref)).
 Possible subtypes of `AttractorsBasinsContinuation` are:
 
 - [`RecurrencesFindAndMatch`](@ref)
-- [`GroupAcrossParameterContinuation`](@ref)
+- [`GroupAcrossParameter`](@ref)
 
 ## Return
 

--- a/src/continuation/basins_fractions_continuation_api.jl
+++ b/src/continuation/basins_fractions_continuation_api.jl
@@ -27,7 +27,7 @@ the dynamical system (as in [`basins_fractions`](@ref)).
 
 Possible subtypes of `AttractorsBasinsContinuation` are:
 
-- [`RecurrencesSeededContinuation`](@ref)
+- [`RecurrencesFindAndMatch`](@ref)
 - [`GroupAcrossParameterContinuation`](@ref)
 
 ## Return

--- a/src/continuation/basins_fractions_continuation_api.jl
+++ b/src/continuation/basins_fractions_continuation_api.jl
@@ -32,10 +32,10 @@ Possible subtypes of `AttractorsBasinsContinuation` are:
 
 ## Return
 
-1. `fractions_curves :: Vector{Dict{Int, Float64}}`. The fractions of basins of attraction.
+1. `fractions_curves::Vector{Dict{Int, Float64}}`. The fractions of basins of attraction.
    `fractions_curves[i]` is a dictionary mapping attractor IDs to their basin fraction
    at the `i`-th parameter.
-2. `attractors_info <: Vector{Dict{Int, <:Any}}`. Information about the attractors.
+2. `attractors_info::Vector{Dict{Int, <:Any}}`. Information about the attractors.
    `attractors_info[i]` is a dictionary mapping attractor ID to information about the
    attractor at the `i`-th parameter.
    The type of information stored depends on the chosen continuation type.

--- a/src/continuation/continuation_grouping.jl
+++ b/src/continuation/continuation_grouping.jl
@@ -1,15 +1,16 @@
-export GroupAcrossParameterContinuation
+export GroupAcrossParameter
 import ProgressMeter
 import Mmap
 
-struct GroupAcrossParameterContinuation{A<:AttractorsViaFeaturizing, E} <: AttractorsBasinsContinuation
+struct GroupAcrossParameter{A<:AttractorsViaFeaturizing, E} <: AttractorsBasinsContinuation
     mapper::A
     info_extraction::E
     par_weight::Float64
 end
 
 """
-    GroupAcrossParameterContinuation(mapper::AttractorsViaFeaturizing; kwargs...)
+    GroupAcrossParameter <: AttractorsBasinsContinuation
+    GroupAcrossParameter(mapper::AttractorsViaFeaturizing; kwargs...)
 
 A method for [`continuation`](@ref).
 It uses the featurizing approach discussed in [`AttractorsViaFeaturizing`](@ref)
@@ -44,12 +45,12 @@ done by the developer team of Attractors.jl.
     Maximilian Gelbrecht et al 2021, Monte Carlo basin bifurcation analysis,
     [New J. Phys.22 03303](http://dx.doi.org/10.1088/1367-2630/ab7a05)
 """
-function GroupAcrossParameterContinuation(
+function GroupAcrossParameter(
         mapper::AttractorsViaFeaturizing;
         info_extraction = mean_across_features,
         par_weight = 0.0,
     )
-    return GroupAcrossParameterContinuation(
+    return GroupAcrossParameter(
         mapper, info_extraction, par_weight
     )
 end
@@ -66,7 +67,7 @@ function mean_across_features(fs)
 end
 
 function continuation(
-        continuation::GroupAcrossParameterContinuation, prange, pidx, ics;
+        continuation::GroupAcrossParameter, prange, pidx, ics;
         show_progress = true, samples_per_parameter = 100
     )
     (; mapper, info_extraction, par_weight) = continuation

--- a/src/continuation/continuation_recurrences.jl
+++ b/src/continuation/continuation_recurrences.jl
@@ -1,22 +1,20 @@
-export RecurrencesSeededContinuation
+export RecurrencesFindAndMatch, RAFM
 import ProgressMeter
 using Random: MersenneTwister
 
 # The recurrences based distance is rather flexible because it works
 # in two independent steps: it first finds attractors and then matches them.
-struct RecurrencesSeededContinuation{A, M, R<:Real, S, E} <: AttractorsBasinsContinuation
-    mapper::A
-    distance::M
-    threshold::R
-    seeds_from_attractor::S
-    info_extraction::E
-end
 
 """
-    RecurrencesSeededContinuation <: AttractorsBasinsContinuation
-    RecurrencesSeededContinuation(mapper::AttractorsViaRecurrences; kwargs...)
+    RAFM <: AttractorsBasinsContinuation
+    RecurrencesFindAndMatch <: AttractorsBasinsContinuation
+    RecurrencesFindAndMatch(mapper::AttractorsViaRecurrences; kwargs...)
 
-A method for [`continuation`](@ref). TODO: Cite our preprint here.
+A method for [`continuation`](@ref) as in [^Datseris2023] that is based on the
+recurrences-based algorithmf or finding attractors ([`AttractorsViaRecurrences`](@ref))
+and the "matching attractors" functionality offered by [`match_attractor_ids!`](@ref).
+
+You can use `RAFM` as an alias.
 
 ## Description
 
@@ -24,19 +22,27 @@ At the first parameter slice attractors and their fractions are found as describ
 [`AttractorsViaRecurrences`](@ref) mapper using recurrences in state space.
 At each subsequent parameter slice,
 new attractors are found by seeding initial conditions from the previously found
-attractors and then piping these initial conditions through the recurrences algorithm
+attractors and then running these initial conditions through the recurrences algorithm
 of the `mapper`. Seeding initial conditions close to previous attractors accelerates
 the main bottleneck of [`AttractorsViaRecurrences`](@ref), which is finding the attractors.
-After the attractors are found, their fractions are computed by running new initial
-conditions through the [`AttractorsViaRecurrences`](@ref) mapper.
-This process continues until all parameter values are exhausted and for each parameter
-value the attractors and their fractions are found.
 
-Then, the different attractors across parameters are matched so that they have
+After the attractors are found, their fractions are computed by sampling new random initial
+(using the provided `sampler` in [`continuation`](@ref)) and mapping them to attractors
+using the [`AttractorsViaRecurrences`](@ref) mapper.
+
+Then, the newly found attractors (and their fractions) are "matched" to the previous ones.
+I.e., their _IDs_ are changed, accoring to the [`match_attractor_ids!`](@ref) function.
+Typically, the matching process matches attractor IDs that are closest in state space
+distance, but mroe options are possible, see.
+] attractors across parameters are matched so that they have
 the same ID. The matching process is based on distances between attractors.
 The function that computes these distances is
 [`setsofsets_distances`](@ref) and the matching function
 is [`match_attractor_ids!`](@ref) (please read those docstrings as well).
+
+This process continues until all parameter values are exhausted and for each parameter
+value the attractors and their fractions are found.
+
 
 At each parameter slice beyond the first, the new
 attractors are matched to the previous attractors found in the previous parameter value
@@ -55,13 +61,25 @@ get assigned the same label.
   parameter slice. By default, we sample some points from existing attractors according
   to how many points the attractors themselves contain. A maximum of `10` seeds is done
   per attractor.
+
+[^Datseris2023]: Datseris, Rossi & Wagemakers 2023: Framework for global stability analysis
 """
-function RecurrencesSeededContinuation(
+struct RecurrencesFindAndMatch{A, M, R<:Real, S, E} <: AttractorsBasinsContinuation
+    mapper::A
+    distance::M
+    threshold::R
+    seeds_from_attractor::S
+    info_extraction::E
+end
+
+RAFM = RecurrencesFindAndMatch
+
+function RecurrencesFindAndMatch(
         mapper::AttractorsViaRecurrences; distance = Centroid(),
         threshold = Inf, seeds_from_attractor = _default_seeding_process,
         info_extraction = identity
     )
-    return RecurrencesSeededContinuation(
+    return RecurrencesFindAndMatch(
         mapper, distance, threshold, seeds_from_attractor, info_extraction
     )
 end
@@ -74,7 +92,7 @@ function _default_seeding_process(attractor::AbstractStateSpaceSet; rng = Mersen
 end
 
 function continuation(
-        rsc::RecurrencesSeededContinuation,
+        rsc::RecurrencesFindAndMatch,
         prange, pidx, ics = _ics_from_grid(rsc);
         samples_per_parameter = 100, show_progress = true,
     )
@@ -168,7 +186,7 @@ function reset!(mapper::AttractorsViaRecurrences)
     return
 end
 
-function _ics_from_grid(rsc::RecurrencesSeededContinuation)
+function _ics_from_grid(rsc::RecurrencesFindAndMatch)
     return _ics_from_grid(rsc.mapper.grid)
 end
 

--- a/src/continuation/continuation_recurrences.jl
+++ b/src/continuation/continuation_recurrences.jl
@@ -6,7 +6,6 @@ using Random: MersenneTwister
 # in two independent steps: it first finds attractors and then matches them.
 
 """
-    RAFM <: AttractorsBasinsContinuation
     RecurrencesFindAndMatch <: AttractorsBasinsContinuation
     RecurrencesFindAndMatch(mapper::AttractorsViaRecurrences; kwargs...)
 
@@ -72,7 +71,8 @@ struct RecurrencesFindAndMatch{A, M, R<:Real, S, E} <: AttractorsBasinsContinuat
     info_extraction::E
 end
 
-RAFM = RecurrencesFindAndMatch
+"Alias for [`RecurrencesFindAndMatch`](@ref)"
+const RAFM = RecurrencesFindAndMatch
 
 function RecurrencesFindAndMatch(
         mapper::AttractorsViaRecurrences; distance = Centroid(),

--- a/src/continuation/continuation_recurrences.jl
+++ b/src/continuation/continuation_recurrences.jl
@@ -16,7 +16,7 @@ end
     RecurrencesSeededContinuation <: AttractorsBasinsContinuation
     RecurrencesSeededContinuation(mapper::AttractorsViaRecurrences; kwargs...)
 
-A method for [`rsc`](@ref). TODO: Cite our preprint here.
+A method for [`continuation`](@ref). TODO: Cite our preprint here.
 
 ## Description
 

--- a/src/continuation/continuation_recurrences.jl
+++ b/src/continuation/continuation_recurrences.jl
@@ -10,14 +10,14 @@ using Random: MersenneTwister
     RecurrencesFindAndMatch(mapper::AttractorsViaRecurrences; kwargs...)
 
 A method for [`continuation`](@ref) as in [^Datseris2023] that is based on the
-recurrences-based algorithmf or finding attractors ([`AttractorsViaRecurrences`](@ref))
+recurrences-based algorithm for finding attractors ([`AttractorsViaRecurrences`](@ref))
 and the "matching attractors" functionality offered by [`match_attractor_ids!`](@ref).
 
 You can use `RAFM` as an alias.
 
 ## Description
 
-At the first parameter slice attractors and their fractions are found as described in the
+At the first parameter slice, attractors and their fractions are found as described in the
 [`AttractorsViaRecurrences`](@ref) mapper using recurrences in state space.
 At each subsequent parameter slice,
 new attractors are found by seeding initial conditions from the previously found
@@ -30,27 +30,15 @@ After the attractors are found, their fractions are computed by sampling new ran
 using the [`AttractorsViaRecurrences`](@ref) mapper.
 
 Then, the newly found attractors (and their fractions) are "matched" to the previous ones.
-I.e., their _IDs_ are changed, accoring to the [`match_attractor_ids!`](@ref) function.
+I.e., their _IDs are changed_, according to the [`match_attractor_ids!`](@ref) function.
 Typically, the matching process matches attractor IDs that are closest in state space
-distance, but mroe options are possible, see.
-] attractors across parameters are matched so that they have
-the same ID. The matching process is based on distances between attractors.
-The function that computes these distances is
-[`setsofsets_distances`](@ref) and the matching function
-is [`match_attractor_ids!`](@ref) (please read those docstrings as well).
+distance, but more options are possible, see [`match_attractor_ids!`](@ref).
 
 This process continues until all parameter values are exhausted and for each parameter
 value the attractors and their fractions are found.
 
-
-At each parameter slice beyond the first, the new
-attractors are matched to the previous attractors found in the previous parameter value
-by a direct call to the [`match_attractor_ids!`](@ref) function. Hence, the matching
-of attractors here works "slice by slice" on the parameter axis and the attractors
-that are closest to each other (in state space, but for two different parameter values)
-get assigned the same label.
-
 ## Keyword arguments
+
 - `distance, threshold`: propagated to [`match_attractor_ids!`](@ref).
 - `info_extraction = identity`: A function that takes as an input an attractor (`StateSpaceSet`)
   and outputs whatever information should be stored. It is used to return the

--- a/src/continuation/match_attractor_ids.jl
+++ b/src/continuation/match_attractor_ids.jl
@@ -16,6 +16,12 @@ Return the replacement map, a dictionary mapping old keys of `a₊` to
 the new ones that they were mapped to. You can obtain this map, without modifying
 the dictionaries, by calling the [`replacement_map`](@ref) function directly.
 
+## Keyword arguments
+
+- `distance = Centroid()`: given to [`setsofsets_distances`](@ref).
+- `threshold = Inf`: attractors with distance more than the `threshold` are guaranteed
+  to not be mapped to each other.
+
 ## Description
 
 When finding attractors and their fractions in DynamicalSystems.jl,
@@ -27,8 +33,10 @@ the different parameters) with different IDs.
 i.e., the keys of the given dictionaries.
 
 The matching happens according to the output of the [`setsofsets_distances`](@ref)
-function with the keyword `distance`. distance` can be whatever that function accepts.
-Attractors are then match according to distance, with unique mapping.
+function with the keyword `distance`. `distance` can be whatever that function accepts,
+i.e., one of `Centroid, Hausdorff, StrictlyMinimumDistance` or any arbitrary user-
+provided function that given two sets it returns a positive number (their distance).
+Attractors are then matched according to this distance, with unique mapping.
 The closest attractors (before and after) are mapped to each
 other, and are removed from the matching pool, and then the next pair with least
 remaining distance is matched, and so on.
@@ -160,7 +168,7 @@ end
 """
     rematch!(fractions_curves, attractors_info; kwargs...)
 
-Given the outputs of [`continuation`](@ref) witn [`RecurrencesSeededContinuation`](@ref),
+Given the outputs of [`continuation`](@ref) witn [`RecurrencesFindAndMatch`](@ref),
 perform the matching step of the process again with the (possibly different) keywords
 that [`match_attractor_ids!`](@ref) accepts. This "re-matching" is possible because in
 [`continuation`](@ref) finding the attractors and their basins is a completely independent

--- a/src/continuation/match_attractor_ids.jl
+++ b/src/continuation/match_attractor_ids.jl
@@ -19,7 +19,7 @@ the dictionaries, by calling the [`replacement_map`](@ref) function directly.
 ## Keyword arguments
 
 - `distance = Centroid()`: given to [`setsofsets_distances`](@ref).
-- `threshold = Inf`: attractors with distance more than the `threshold` are guaranteed
+- `threshold = Inf`: attractors with distance larger than the `threshold` are guaranteed
   to not be mapped to each other.
 
 ## Description

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -13,3 +13,6 @@ function basins_of_attraction(grid::Tuple, ds::DynamicalSystem; kwargs...)
     Please use that method instead.
     """)
 end
+
+
+@deprecate RecurrencesFindAndMatch RecurrencesFindAndMatch

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -15,4 +15,5 @@ function basins_of_attraction(grid::Tuple, ds::DynamicalSystem; kwargs...)
 end
 
 
-@deprecate RecurrencesFindAndMatch RecurrencesFindAndMatch
+@deprecate RecurrencesSeededContinuation RecurrencesFindAndMatch
+@deprecate GroupAcrossParameterContinuation GroupAcrossParameter

--- a/test/continuation/grouping_continuation.jl
+++ b/test/continuation/grouping_continuation.jl
@@ -36,7 +36,7 @@ using Random
     featurizer(a, t) = a[end]
     clusterspecs = Attractors.GroupViaClustering(optimal_radius_method = "silhouettes", max_used_features = 200)
     mapper = Attractors.AttractorsViaFeaturizing(ds, featurizer, clusterspecs; T = 20, threaded = true)
-    continuation = GroupAcrossParameterContinuation(mapper; par_weight = 1.)
+    continuation = GroupAcrossParameter(mapper; par_weight = 1.)
     fractions_curves, attractors_info = Attractors.continuation(
     continuation, rrange, ridx, sampler; show_progress = false)
 
@@ -102,7 +102,7 @@ if DO_EXTENSIVE_TESTS
         end
         clusterspecs = Attractors.GroupViaClustering(optimal_radius_method = 1.)
         mapper = Attractors.AttractorsViaFeaturizing(ds, featurizer, clusterspecs; T = 500, threaded = true)
-        continuation = GroupAcrossParameterContinuation(mapper; par_weight = 1.0)
+        continuation = GroupAcrossParameter(mapper; par_weight = 1.0)
         fractions_curves, attractors_info = Attractors.continuation(
             continuation, ps, pidx, sampler;
             samples_per_parameter = 1000, show_progress = false

--- a/test/continuation/matching_attractors.jl
+++ b/test/continuation/matching_attractors.jl
@@ -58,6 +58,14 @@ end
         @test !haskey(allatts2[i], 2)
     end
     @test haskey(allatts2[1], 2)
+    # Test rematch function
+    allatts3 = deepcopy(allatts2)
+    fracs = [Dict(k => 0.5 for (k, v) in att) for att in allatts3]
+    @test unique_keys(fracs) == 1:11
+    # Same matching as in `allatts`
+    rematch!(fracs, allatts3; threshold = 100.0)
+    @test unique_keys(fracs) == 1:2
+    @test unique_keys(allatts3) == 1:2
 end
 
 

--- a/test/continuation/recurrences_continuation.jl
+++ b/test/continuation/recurrences_continuation.jl
@@ -37,7 +37,7 @@ using Random
 
     rrange = range(0, 2; length = 20)
     ridx = 1
-    rsc = RecurrencesSeededContinuation(mapper; threshold = 0.3)
+    rsc = RecurrencesFindAndMatch(mapper; threshold = 0.3)
     fractions_curves, a = continuation(
         rsc, rrange, ridx, sampler;
         show_progress = false, samples_per_parameter = 1000
@@ -137,7 +137,7 @@ end
     ridx = 1
     # First, test the normal function of finding attractors
     mapper = AttractorsViaRecurrences(ds, grid; sparse = true, show_progress = false)
-    rsc = RecurrencesSeededContinuation(mapper; threshold = 0.1)
+    rsc = RecurrencesFindAndMatch(mapper; threshold = 0.1)
     fractions_curves, attractors_info = continuation(
         rsc, rrange, ridx, sampler;
         show_progress = false, samples_per_parameter = 1000,
@@ -218,7 +218,7 @@ if DO_EXTENSIVE_TESTS
         mx_chk_fnd_att = 3000,
         mx_chk_loc_att = 3000
     )
-    rsc = RecurrencesSeededContinuation(mapper;
+    rsc = RecurrencesFindAndMatch(mapper;
         threshold = 0.99, distance = distance_function
     )
     ps = psorig
@@ -287,7 +287,7 @@ end
         min_bounds = [-2,-2], max_bounds = [2,2]
     )
     mapper = AttractorsViaRecurrences(ds, (xg, yg); sparse=false)
-    rsc = RecurrencesSeededContinuation(mapper)
+    rsc = RecurrencesFindAndMatch(mapper)
 
     fractions_curves, attractors_info = continuation(
         rsc, ps, pidx, sampler;
@@ -313,7 +313,7 @@ end
         # test that both finding and removing attractor works
         mapper = AttractorsViaRecurrences(ds, (xg, yg); sparse=false, Δt = 1.0)
 
-        continuation = RecurrencesSeededContinuation(mapper; threshold = Inf)
+        continuation = RecurrencesFindAndMatch(mapper; threshold = Inf)
         # With this threshold all attractors are mapped to each other, they are within
         # distance 1 in state space.
         fractions_curves, attractors_info = continuation(


### PR DESCRIPTION
- Added `rematch!` to do different matching after the continuation has stopped
- Renamed the continuation methods: `RecurrencesFindAndMatch` and `GroupAcrossParameter`. I've dropped `Continuation` from both names, as they subtype the `AttractorsBasinsContinuation` abstract type


Let me know if you disagree. 