### PR TITLE
Renames and docs improve clarity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v1.7
+
 - Some functions have been renamed for higher level of clarity (deprecations have been put in place):
-  - `match_attractors_ids!` -> `match_statespacesets!`
+  - `match_attractor_ids!` -> `match_statespacesets!`
   - `GroupAcrossParameter` -> `FeaturizeGroupAcrossParameter`.
 
 # v1.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v1.7
+- Some functions have been renamed for higher level of clarity (deprecations have been put in place):
+  - `match_attractors_ids!` -> `match_statespacesets!`
+  - `GroupAcrossParameter` -> `FeaturizeGroupAcrossParameter`.
+
 # v1.6
 - Attractors.jl moved to Julia 1.9+
 - Plotting utility functions are now part of the API using package extensions. They are exported, documented, and used in the examples.

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Attractors"
 uuid = "f3fd9213-ca85-4dba-9dfd-7fc91308fec7"
 authors = ["George Datseris <datseris.george@gmail.com>", "Kalel Rossi", "Alexandre Wagemakers"]
 repo = "https://github.com/JuliaDynamics/Attractors.jl.git"
-version = "1.6.1"
+version = "1.7.0"
 
 [deps]
 Clustering = "aaaa29a8-35af-508c-8bc3-b662a17a0fe5"

--- a/docs/src/continuation.md
+++ b/docs/src/continuation.md
@@ -21,7 +21,7 @@ RecurrencesFindAndMatch
 
 ## Matching attractors
 ```@docs
-match_attractor_ids!
+match_statespacesets!
 replacement_map
 set_distance
 setsofsets_distances
@@ -36,5 +36,5 @@ aggregate_attractor_fractions
 
 ## Grouping continuation
 ```@docs
-GroupAcrossParameter
+FeaturizeGroupAcrossParameter
 ```

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -117,7 +117,7 @@ basins_after, attractors_after = basins_of_attraction(
     mapper, (xg, yg); show_progress = false
 )
 # matching attractors is important!
-rmap = match_attractor_ids!(attractors_after, attractors)
+rmap = match_statespacesets!(attractors_after, attractors)
 # Don't forget to update the labels of the basins as well!
 replace!(basins_after, rmap...)
 
@@ -388,7 +388,7 @@ As expected, the fractions are each about 1/3 due to the system symmetry.
 
 ## Featurizing and grouping across parameters (MCBB)
 Here we showcase the example of the Monte Carlo Basin Bifurcation publication.
-For this, we will use [`GroupAcrossParameter`](@ref) while also providing a `par_weight = 1` keyword.
+For this, we will use [`FeaturizeGroupAcrossParameter`](@ref) while also providing a `par_weight = 1` keyword.
 However, we will not use a network of 2nd order Kuramoto oscillators (as done in the paper by Gelbrecht et al.) because it is too costly to run on CI.
 Instead, we will use "dummy" system which we know analytically the attractors and how they behave versus a parameter.
 
@@ -429,7 +429,7 @@ ridx = 1
 featurizer(a, t) = a[end]
 clusterspecs = GroupViaClustering(optimal_radius_method = "silhouettes", max_used_features = 200)
 mapper = AttractorsViaFeaturizing(ds, featurizer, clusterspecs; T = 20, threaded = true)
-gap = GroupAcrossParameter(mapper; par_weight = 1.0)
+gap = FeaturizeGroupAcrossParameter(mapper; par_weight = 1.0)
 fractions_curves, clusters_info = continuation(
     gap, rrange, ridx, sampler; show_progress = false
 )

--- a/src/continuation/aggregate_attractor_fractions.jl
+++ b/src/continuation/aggregate_attractor_fractions.jl
@@ -34,7 +34,7 @@ in [Extinction of a species in a multistable competition model](@ref).
    to be grouped later. Features expected by [`GroupingConfig`](@ref) are `SVector`.
 4. `group_config`: a subtype of [`GroupingConfig`](@ref).
 5. `info_extraction`: a function accepting a vector of features and returning a description
-   of the features. I.e., exactly as in [`GroupAcrossParameter`](@ref).
+   of the features. I.e., exactly as in [`FeaturizeGroupAcrossParameter`](@ref).
    The 5th argument is optional and defaults to the centroid of the features.
 
 ## Return

--- a/src/continuation/basins_fractions_continuation_api.jl
+++ b/src/continuation/basins_fractions_continuation_api.jl
@@ -30,7 +30,7 @@ the dynamical system (as in [`basins_fractions`](@ref)).
 Possible subtypes of `AttractorsBasinsContinuation` are:
 
 - [`RecurrencesFindAndMatch`](@ref)
-- [`GroupAcrossParameter`](@ref)
+- [`FeaturizeGroupAcrossParameter`](@ref)
 
 ## Return
 

--- a/src/continuation/continuation_grouping.jl
+++ b/src/continuation/continuation_grouping.jl
@@ -1,16 +1,16 @@
-export GroupAcrossParameter
+export FeaturizeGroupAcrossParameter
 import ProgressMeter
 import Mmap
 
-struct GroupAcrossParameter{A<:AttractorsViaFeaturizing, E} <: AttractorsBasinsContinuation
+struct FeaturizeGroupAcrossParameter{A<:AttractorsViaFeaturizing, E} <: AttractorsBasinsContinuation
     mapper::A
     info_extraction::E
     par_weight::Float64
 end
 
 """
-    GroupAcrossParameter <: AttractorsBasinsContinuation
-    GroupAcrossParameter(mapper::AttractorsViaFeaturizing; kwargs...)
+    FeaturizeGroupAcrossParameter <: AttractorsBasinsContinuation
+    FeaturizeGroupAcrossParameter(mapper::AttractorsViaFeaturizing; kwargs...)
 
 A method for [`continuation`](@ref).
 It uses the featurizing approach discussed in [`AttractorsViaFeaturizing`](@ref)
@@ -45,12 +45,12 @@ done by the developer team of Attractors.jl.
     Maximilian Gelbrecht et al 2021, Monte Carlo basin bifurcation analysis,
     [New J. Phys.22 03303](http://dx.doi.org/10.1088/1367-2630/ab7a05)
 """
-function GroupAcrossParameter(
+function FeaturizeGroupAcrossParameter(
         mapper::AttractorsViaFeaturizing;
         info_extraction = mean_across_features,
         par_weight = 0.0,
     )
-    return GroupAcrossParameter(
+    return FeaturizeGroupAcrossParameter(
         mapper, info_extraction, par_weight
     )
 end
@@ -67,7 +67,7 @@ function mean_across_features(fs)
 end
 
 function continuation(
-        continuation::GroupAcrossParameter, prange, pidx, ics;
+        continuation::FeaturizeGroupAcrossParameter, prange, pidx, ics;
         show_progress = true, samples_per_parameter = 100
     )
     (; mapper, info_extraction, par_weight) = continuation

--- a/src/continuation/continuation_recurrences.jl
+++ b/src/continuation/continuation_recurrences.jl
@@ -11,7 +11,7 @@ using Random: MersenneTwister
 
 A method for [`continuation`](@ref) as in [^Datseris2023] that is based on the
 recurrences-based algorithm for finding attractors ([`AttractorsViaRecurrences`](@ref))
-and the "matching attractors" functionality offered by [`match_attractor_ids!`](@ref).
+and the "matching attractors" functionality offered by [`match_statespacesets!`](@ref).
 
 You can use `RAFM` as an alias.
 
@@ -31,9 +31,9 @@ using the [`AttractorsViaRecurrences`](@ref) mapper.
 I.e., exactly as in [`basins_fractions`](@ref).
 
 Then, the newly found attractors (and their fractions) are "matched" to the previous ones.
-I.e., their _IDs are changed_, according to the [`match_attractor_ids!`](@ref) function.
+I.e., their _IDs are changed_, according to the [`match_statespacesets!`](@ref) function.
 Typically, the matching process matches attractor IDs that are closest in state space
-distance, but more options are possible, see [`match_attractor_ids!`](@ref).
+distance, but more options are possible, see [`match_statespacesets!`](@ref).
 
 This process continues until all parameter values are exhausted and for each parameter
 value the attractors and their fractions are found.
@@ -44,7 +44,7 @@ outcome of the matching process, you may call [`rematch!`](@ref) on the outcome.
 
 ## Keyword arguments
 
-- `distance, threshold`: propagated to [`match_attractor_ids!`](@ref).
+- `distance, threshold`: propagated to [`match_statespacesets!`](@ref).
 - `info_extraction = identity`: A function that takes as an input an attractor (`StateSpaceSet`)
   and outputs whatever information should be stored. It is used to return the
   `attractors_info` in [`continuation`](@ref).
@@ -146,7 +146,7 @@ function continuation(
         if !isempty(current_attractors) && !isempty(prev_attractors)
             # If there are any attractors,
             # match with previous attractors before storing anything!
-            rmap = match_attractor_ids!(
+            rmap = match_statespacesets!(
                 current_attractors, prev_attractors; distance, threshold
             )
             swap_dict_keys!(fs, rmap)

--- a/src/continuation/match_attractor_ids.jl
+++ b/src/continuation/match_attractor_ids.jl
@@ -7,8 +7,8 @@ export match_statespacesets!, match_basins_ids!, replacement_map, rematch!
 """
     match_statespacesets!(a₊::AbstractDict, a₋; distance = Centroid(), threshold = Inf)
 
-Given dictionaries `a₊, a₋` mapping IDs to attractors (`StateSpaceSet` instances),
-match attractor IDs in dictionary `a₊` so that its attractors that are the closest to
+Given dictionaries `a₊, a₋` mapping IDs to `StateSpaceSet` instances,
+match the IDs in dictionary `a₊` so that its sets that are the closest to
 those in dictionary `a₋` get assigned the same key as in `a₋`.
 Typically the +,- mean after and before some change of parameter of a system.
 
@@ -24,19 +24,22 @@ the dictionaries, by calling the [`replacement_map`](@ref) function directly.
 
 ## Description
 
-When finding attractors and their fractions in DynamicalSystems.jl,
+When finding attractors and their fractions in Attractors.jl,
 different attractors get assigned different IDs. However
 which attractor gets which ID is somewhat arbitrary. Finding the attractors of the
 same system for slightly different parameters could label "similar" attractors (at
 the different parameters) with different IDs.
-`match_attractors_ids!` tries to "match" them by modifying the attractor IDs,
-i.e., the keys of the given dictionaries.
+`match_statespacesets!` tries to "match" them by modifying the IDs,
+i.e., the keys of the given dictionaries. Do note however that there is nothing
+in this function that is limited to attractors in the formal mathematical sense.
+Any dictionary with `StateSpaceSet` values is a valid input and these sets
+may represent attractors, trajectories, group of features, or anything else.
 
 The matching happens according to the output of the [`setsofsets_distances`](@ref)
 function with the keyword `distance`. `distance` can be whatever that function accepts,
 i.e., one of `Centroid, Hausdorff, StrictlyMinimumDistance` or any arbitrary user-
 provided function that given two sets it returns a positive number (their distance).
-Attractors are then matched according to this distance, with unique mapping.
+State space sets are then matched according to this distance, with unique mapping.
 The closest attractors (before and after) are mapped to each
 other, and are removed from the matching pool, and then the next pair with least
 remaining distance is matched, and so on.

--- a/src/continuation/match_attractor_ids.jl
+++ b/src/continuation/match_attractor_ids.jl
@@ -1,11 +1,11 @@
 # Notice this file uses heavily `dict_utils.jl`!
-export match_attractor_ids!, match_basins_ids!, replacement_map, rematch!
+export match_statespacesets!, match_basins_ids!, replacement_map, rematch!
 
 ###########################################################################################
 # Matching attractors and key swapping business
 ###########################################################################################
 """
-    match_attractor_ids!(a₊::AbstractDict, a₋; distance = Centroid(), threshold = Inf)
+    match_statespacesets!(a₊::AbstractDict, a₋; distance = Centroid(), threshold = Inf)
 
 Given dictionaries `a₊, a₋` mapping IDs to attractors (`StateSpaceSet` instances),
 match attractor IDs in dictionary `a₊` so that its attractors that are the closest to
@@ -45,29 +45,29 @@ Additionally, you can provide a `threshold` value. If the distance between two a
 is larger than this `threshold`, then it is guaranteed that the attractors will get assigned
 different key in the dictionary `a₊`.
 """
-function match_attractor_ids!(a₊::AbstractDict, a₋; kwargs...)
+function match_statespacesets!(a₊::AbstractDict, a₋; kwargs...)
     rmap = replacement_map(a₊, a₋; kwargs...)
     swap_dict_keys!(a₊, rmap)
     return rmap
 end
 
 """
-    match_attractor_ids!(attractors_info::Vector{<:Dict}; kwargs...)
+    match_statespacesets!(attractors_info::Vector{<:Dict}; kwargs...)
 
 Convenience method that progresses through the dictionaries in `attractors_info` in sequence
 and matches them using same keywords as the above method.
 """
-function match_attractor_ids!(as::Vector{<:Dict}; kwargs...)
+function match_statespacesets!(as::Vector{<:Dict}; kwargs...)
     for i in 1:length(as)-1
         a₊, a₋ = as[i+1], as[i]
-        match_attractor_ids!(a₊, a₋; kwargs...)
+        match_statespacesets!(a₊, a₋; kwargs...)
     end
 end
 
 """
     replacement_map(a₊, a₋; distance = Centroid(), threshold = Inf) → rmap
 Return a dictionary mapping keys in `a₊` to new keys in `a₋`,
-as explained in [`match_attractor_ids!`](@ref).
+as explained in [`match_statespacesets!`](@ref).
 """
 function replacement_map(a₊::Dict, a₋::Dict; distance = Centroid(), threshold = Inf)
     distances = setsofsets_distances(a₊, a₋, distance)
@@ -128,7 +128,7 @@ end
 ###########################################################################################
 """
     match_basins_ids!(b₊::AbstractArray, b₋; threshold = Inf)
-Similar to [`match_attractor_ids!`](@ref) but operate on basin arrays instead
+Similar to [`match_statespacesets!`](@ref) but operate on basin arrays instead
 (the arrays typically returned by [`basins_of_attraction`](@ref)).
 
 This method matches IDs of attractors whose basins of attraction before and after `b₋,b₊`
@@ -170,14 +170,14 @@ end
 
 Given the outputs of [`continuation`](@ref) witn [`RecurrencesFindAndMatch`](@ref),
 perform the matching step of the process again with the (possibly different) keywords
-that [`match_attractor_ids!`](@ref) accepts. This "re-matching" is possible because in
+that [`match_statespacesets!`](@ref) accepts. This "re-matching" is possible because in
 [`continuation`](@ref) finding the attractors and their basins is a completely independent
 step from matching them with their IDs in the previous parameter value.
 """
 function rematch!(fractions_curves, attractors_info; kwargs...)
     for i in 1:length(attractors_info)-1
         a₊, a₋ = attractors_info[i+1], attractors_info[i]
-        rmap = match_attractor_ids!(a₊, a₋; kwargs...)
+        rmap = match_statespacesets!(a₊, a₋; kwargs...)
         swap_dict_keys!(fractions_curves[i+1], rmap)
     end
     rmap = retract_keys_to_consecutive(fractions_curves)

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -14,6 +14,7 @@ function basins_of_attraction(grid::Tuple, ds::DynamicalSystem; kwargs...)
     """)
 end
 
-
 @deprecate RecurrencesSeededContinuation RecurrencesFindAndMatch
-@deprecate GroupAcrossParameterContinuation GroupAcrossParameter
+@deprecate GroupAcrossParameterContinuation FeaturizeGroupAcrossParameter
+@deprecate match_attractor_ids! match_statespacesets!
+@deprecate GroupAcrossParameter FeaturizeGroupAcrossParameter

--- a/test/continuation/grouping_continuation.jl
+++ b/test/continuation/grouping_continuation.jl
@@ -36,7 +36,7 @@ using Random
     featurizer(a, t) = a[end]
     clusterspecs = Attractors.GroupViaClustering(optimal_radius_method = "silhouettes", max_used_features = 200)
     mapper = Attractors.AttractorsViaFeaturizing(ds, featurizer, clusterspecs; T = 20, threaded = true)
-    gap = GroupAcrossParameter(mapper; par_weight = 0.0)
+    gap = FeaturizeGroupAcrossParameter(mapper; par_weight = 0.0)
     fractions_curves, attractors_info = continuation(
         gap, rrange, ridx, sampler; show_progress = false
     )
@@ -107,7 +107,7 @@ if DO_EXTENSIVE_TESTS
         mapper = Attractors.AttractorsViaFeaturizing(ds, featurizer, clusterspecs;
             T = 10, Ttr = 2000, threaded = true
         )
-        gap = GroupAcrossParameter(mapper; par_weight = 0.0)
+        gap = FeaturizeGroupAcrossParameter(mapper; par_weight = 0.0)
         fractions_curves, attractors_info = continuation(
             gap, ps, pidx, sampler;
             samples_per_parameter = 100, show_progress = false

--- a/test/continuation/matching_attractors.jl
+++ b/test/continuation/matching_attractors.jl
@@ -8,7 +8,7 @@ DO_EXTENSIVE_TESTS = get(ENV, "ATTRACTORS_EXTENSIVE_TESTS", "false") == "true"
     @testset "infinite threshold" begin
         a_afte = Dict(2 => [SVector(0.0, 0.0)], 1 => [SVector(2.0, 2.0)])
         a_afte = Dict(keys(a_afte) .=> StateSpaceSet.(values(a_afte)))
-        rmap = match_attractor_ids!(a_afte, a_befo)
+        rmap = match_statespacesets!(a_afte, a_befo)
         @test rmap == Dict(1 => 2, 2 => 1)
         @test a_afte[1] == a_befo[1] == StateSpaceSet([SVector(0.0, 0.0)])
         @test haskey(a_afte, 2)
@@ -17,7 +17,7 @@ DO_EXTENSIVE_TESTS = get(ENV, "ATTRACTORS_EXTENSIVE_TESTS", "false") == "true"
     @testset "separating threshold" begin
         a_afte = Dict(2 => [SVector(0.0, 0.0)], 1 => [SVector(2.0, 2.0)])
         a_afte = Dict(keys(a_afte) .=> StateSpaceSet.(values(a_afte)))
-        rmap = match_attractor_ids!(a_afte, a_befo; threshold = 0.1)
+        rmap = match_statespacesets!(a_afte, a_befo; threshold = 0.1)
         @test rmap == Dict(1 => 3, 2 => 1)
         @test a_afte[1] == a_befo[1] == StateSpaceSet([SVector(0.0, 0.0)])
         @test !haskey(a_afte, 2)
@@ -46,12 +46,12 @@ end
         end
     end
     # Test with distance not enough to increment
-    match_attractor_ids!(allatts; threshold = 100.0) # all odd keys become 1
+    match_statespacesets!(allatts; threshold = 100.0) # all odd keys become 1
     @test all(haskey(d, 1) for d in allatts)
     @test all(haskey(d, 2) for d in allatts)
     # Test with distance enough to increment
     allatts2 = deepcopy(allatts)
-    match_attractor_ids!(allatts2; threshold = 0.1) # all keys there were `2` get incremented
+    match_statespacesets!(allatts2; threshold = 0.1) # all keys there were `2` get incremented
     @test all(haskey(d, 1) for d in allatts2)
     for i in 2:length(jrange)
         @test haskey(allatts2[i], i+1)
@@ -84,7 +84,7 @@ if DO_EXTENSIVE_TESTS
             mapper = AttractorsViaRecurrences(ds, (xg, yg); sparse = false, Δt = 1.0)
             b₊, a₊ = basins_of_attraction(mapper; show_progress = false)
             @testset "distances match" begin
-                rmap = match_attractor_ids!(a₊, a₋)
+                rmap = match_statespacesets!(a₊, a₋)
                 for k in keys(a₊)
                     dist = minimum(norm(x .- y) for x ∈ a₊[k] for y ∈ a₋[k])
                     @test dist < 0.2


### PR DESCRIPTION
Some functions have been renamed for higher level of clarity (deprecations have been put in place):
  - `match_attractor_ids!` -> `match_statespacesets!`
  - `GroupAcrossParameter` -> `FeaturizeGroupAcrossParameter`.

Will also adjust docstring of `match_statespacesets!` to not be too focused on attractors.