### PR TITLE
Rematch, v2: a new dawn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v1.9
+- Matching attractors during the continuation with `RAFM` has been improved and is done by the function `match_continuation!` which has two options regarding how to handle attractors of previous parameters that have vanished.
+
 # v1.8
 - New algorithm `minimal_fatal_shock` that finds the minimal perturbation for arbitrary initial condition `u0` which will kick the system into different from the current basin.
 

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Attractors"
 uuid = "f3fd9213-ca85-4dba-9dfd-7fc91308fec7"
 authors = ["George Datseris <datseris.george@gmail.com>", "Kalel Rossi", "Alexandre Wagemakers"]
 repo = "https://github.com/JuliaDynamics/Attractors.jl.git"
-version = "1.8.0"
+version = "1.9.0"
 
 [deps]
 BlackBoxOptim = "a134a8b2-14d6-55f6-9291-3336d3ab0209"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+# sample regex patterns
+ignore:
+  - "src/deprecated.jl"  # ignore folders and all its contents

--- a/docs/src/continuation.md
+++ b/docs/src/continuation.md
@@ -1,6 +1,7 @@
 # Attractor & Basins Continuation
 
 ## A new kind of continuation
+
 If you have heard before the word "continuation", then you are likely aware of the **traditional continuation-based bifurcation analysis (CBA)** offered by many software, such as AUTO, MatCont, and in Julia [BifurcationKit.jl](https://github.com/bifurcationkit/BifurcationKit.jl). Here we offer a completely different kind of continuation called **attractors & basins continuation**.
 
 A direct comparison of the two approaches is not truly possible, because they do different things. The traditional linearized continuation analysis continues the curves of individual fixed points across the joint state-parameter space. The attractor and basins continuation first finds all attractors at all parameter values and then _matches_ appropriately similar attractors across different parameters, giving the illusion of continuing them individually. Additionally, the curves of stable fixed points in the joint parameter space is only a small by-product of the attractor basins continuation, and the main information is the basin fractions and how these change in the parameter space.
@@ -20,21 +21,24 @@ RecurrencesFindAndMatch
 ```
 
 ## Matching attractors
+
 ```@docs
 match_statespacesets!
 replacement_map
 set_distance
 setsofsets_distances
+match_continuation!
 match_basins_ids!
-rematch!
 ```
 
 ## Aggregating attractors and fractions
+
 ```@docs
 aggregate_attractor_fractions
 ```
 
 ## Grouping continuation
+
 ```@docs
 FeaturizeGroupAcrossParameter
 ```

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -309,7 +309,7 @@ We visualize them using a predefined function that you can find in `docs/basins_
 
 ```@example MAIN
 # careful; `prange` isn't a vector of reals!
-basins_curves_plot(fractions_curves, γγ)
+plot_basins_curves(fractions_curves, γγ)
 ```
 
 
@@ -370,7 +370,7 @@ fractions_curves, attractors_info = continuation(
     continuation, prange, pidx, sampler;
     show_progress = true, samples_per_parameter
 );
-basins_curves_plot(fractions_curves, prange; separatorwidth = 1)
+plot_basins_curves(fractions_curves, prange; separatorwidth = 1)
 ```
 
 ![](https://raw.githubusercontent.com/JuliaDynamics/JuliaDynamics/master/videos/attractors/multispecies_competition_fractions.png)
@@ -401,7 +401,7 @@ aggregated_fractions, aggregated_info = aggregate_attractor_fractions(
     fractions_curves, attractors_info, featurizer, groupingconfig
 )
 
-basins_curves_plot(aggregated_fractions, prange;
+plot_basins_curves(aggregated_fractions, prange;
     separatorwidth = 1, colors = ["green", "black"],
     labels = Dict(1 => "extinct", 2 => "alive"),
 )

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -10,8 +10,9 @@ using CairoMakie, Attractors
 
 ## Latest news
 
-Our pre-print that discusses the global stability analysis framework offered by Attractors.jl ([`continuation`](@ref)) and the novel continuation offered by [`RecurrencesFindAndMatch`](@ref) is now online: https://arxiv.org/abs/2304.12786 !
-
+- Our paper on the global stability analysis framework offered by Attractors.jl ([`continuation`](@ref)) and the novel continuation offered by [`RecurrencesFindAndMatch`](@ref) is published as a _Featured Article_ in Chaos (https://pubs.aip.org/aip/cha/article/33/7/073151/2904709/Framework-for-global-stability-analysis-of) and has been featured in the AIP publishing showcase (https://www.growkudos.com/publications/10.1063%25252F5.0159675/reader)
+- New function [`minimal_fatal_shock`](@ref)
+- New function [`match_continuation!`](@ref) which improves the matching during a continuation process where attractors dissapear and re-appear.
 
 ## Outline of Attractors.jl
 

--- a/src/continuation/continuation_recurrences.jl
+++ b/src/continuation/continuation_recurrences.jl
@@ -25,26 +25,33 @@ attractors and then running these initial conditions through the recurrences alg
 of the `mapper`. Seeding initial conditions close to previous attractors accelerates
 the main bottleneck of [`AttractorsViaRecurrences`](@ref), which is finding the attractors.
 
-After the attractors are found, their fractions are computed by sampling new random initial
+After the special initial conditions are mapped to attractors, attractor basin fractions
+are computed by sampling random initial conditions.
 (using the provided `sampler` in [`continuation`](@ref)) and mapping them to attractors
 using the [`AttractorsViaRecurrences`](@ref) mapper.
 I.e., exactly as in [`basins_fractions`](@ref).
+Naturally, during this step new attractors may be found, besides those found
+using the "seeding from previous attractors".
+Once the basins fractions are computed,
+the parameter is incremented again and we perform the steps as before.
 
-Then, the newly found attractors (and their fractions) are "matched" to the previous ones.
-I.e., their _IDs are changed_, according to the [`match_statespacesets!`](@ref) function.
+This process continues for all parameter values. After all parameters are exhausted,
+the newly found attractors (and their fractions) are "matched" to the previous ones.
+I.e., their _IDs are changed_, so that attractors with closest distance to those at a
+previous parameter get assigned the same ID.
+Matching is rather sophisticated and is described in
+[`match_statespacesets!`](@ref) and [`match_continuation!`](@ref).
 Typically, the matching process matches attractor IDs that are closest in state space
 distance, but more options are possible, see [`match_statespacesets!`](@ref).
 
-This process continues until all parameter values are exhausted and for each parameter
-value the attractors and their fractions are found.
-
-Note that since in this continuation the finding-attractors and matching-attractors
+Note that in this continuation the finding-attractors and matching-attractors
 steps are completely independent. This means, that if you don't like the initial
-outcome of the matching process, you may call [`match_continuation!`](@ref) on the outcome.
+outcome of the matching process, you may call [`match_continuation!`](@ref) again
+on the outcome with (possibly different) matching-related keywords.
 
 ## Keyword arguments
 
-- `distance, threshold`: propagated to [`match_statespacesets!`](@ref).
+- `distance, threshold, use_vanished`: propagated to [`match_continuation!`](@ref).
 - `info_extraction = identity`: A function that takes as an input an attractor (`StateSpaceSet`)
   and outputs whatever information should be stored. It is used to return the
   `attractors_info` in [`continuation`](@ref). Note that the same attractors that

--- a/src/continuation/continuation_recurrences.jl
+++ b/src/continuation/continuation_recurrences.jl
@@ -156,7 +156,7 @@ function continuation(
         ProgressMeter.next!(progress; showvalues = [("previous parameter", p),])
     end
     # Match attractors (and basins)
-    rematch!(fractions_curves, attractors_info; distance, threshold)
+    match_continuation!(fractions_curves, attractors_info; distance, threshold)
     return fractions_curves, attractors_info
 end
 

--- a/src/continuation/continuation_recurrences.jl
+++ b/src/continuation/continuation_recurrences.jl
@@ -198,10 +198,24 @@ step from matching them with their IDs in the previous parameter value.
 - `use_vanished = false`: HOW TO NAME THIS
 
 """
-function rematch_continuation!(fractions_curves, attractors_info; kwargs...)
+function rematch_continuation!(fractions_curves, attractors_info; used_vanished = false, kwargs...)
+    if !used_vanished
+        _rematch_ignored!(fractions_curves, attractors_info; kwargs...)
+    else
+        error("not implemented yet!")
+    end
+end
+
+function _rematch_ignored!(fractions_curves, attractors_info; kwargs...)
+    # TODO: Set `next_id` correctly!
+    next_id = 1
     for i in 1:length(attractors_info)-1
         a₊, a₋ = attractors_info[i+1], attractors_info[i]
-        rmap = match_statespacesets!(a₊, a₋; kwargs...)
+        # Here we always compute a next id. In this way, if an attractor dissapears
+        # and re-appears, it will get a different (incremented) id as it should!
+        next_id_a = max(maximum(keys(a₊)), maximum(keys(a₋))) + 1
+        next_id = max(next_id+1, next_id_a)
+        rmap = match_statespacesets!(a₊, a₋; next_id, kwargs...)
         swap_dict_keys!(fractions_curves[i+1], rmap)
     end
     rmap = retract_keys_to_consecutive(fractions_curves)

--- a/src/continuation/match_attractor_ids.jl
+++ b/src/continuation/match_attractor_ids.jl
@@ -1,5 +1,5 @@
 # Notice this file uses heavily `dict_utils.jl`!
-export match_statespacesets!, match_basins_ids!, replacement_map, rematch!
+export match_statespacesets!, match_basins_ids!, replacement_map
 
 ###########################################################################################
 # Matching attractors and key swapping business
@@ -164,29 +164,4 @@ function _similarity_from_overlaps(b₊, ids₊, b₋, ids₋)
         distances[i] = d
     end
     return distances
-end
-
-###########################################################################################
-# Rematch! (which can be used after continuation)
-###########################################################################################
-"""
-    rematch!(fractions_curves, attractors_info; kwargs...)
-
-Given the outputs of [`continuation`](@ref) witn [`RecurrencesFindAndMatch`](@ref),
-perform the matching step of the process again with the (possibly different) keywords
-that [`match_statespacesets!`](@ref) accepts. This "re-matching" is possible because in
-[`continuation`](@ref) finding the attractors and their basins is a completely independent
-step from matching them with their IDs in the previous parameter value.
-"""
-function rematch!(fractions_curves, attractors_info; kwargs...)
-    for i in 1:length(attractors_info)-1
-        a₊, a₋ = attractors_info[i+1], attractors_info[i]
-        rmap = match_statespacesets!(a₊, a₋; kwargs...)
-        swap_dict_keys!(fractions_curves[i+1], rmap)
-    end
-    rmap = retract_keys_to_consecutive(fractions_curves)
-    for (da, df) in zip(attractors_info, fractions_curves)
-        swap_dict_keys!(da, rmap)
-        swap_dict_keys!(df, rmap)
-    end
 end

--- a/src/continuation/match_attractor_ids.jl
+++ b/src/continuation/match_attractor_ids.jl
@@ -187,8 +187,8 @@ function match_continuation!(attractors_info; kwargs...)
     fractions_curves = [Dict(k => nothing for k in keys(d)) for d in attractors_info]
     match_continuation!(fractions_curves, attractors_info; kwargs...)
 end
-function match_continuation!(fractions_curves, attractors_info; used_vanished = false, kwargs...)
-    if !used_vanished
+function match_continuation!(fractions_curves, attractors_info; use_vanished = false, kwargs...)
+    if !use_vanished
         _rematch_ignored!(fractions_curves, attractors_info; kwargs...)
     else
         error("not implemented yet!")

--- a/src/continuation/match_attractor_ids.jl
+++ b/src/continuation/match_attractor_ids.jl
@@ -188,6 +188,11 @@ attractor will _not_ have ID 3, but 4 (i.e., the next available ID).
 By default `use_vanished = !isinf(threshold)` and since the default value for
 `threshold` is `Inf`, `use_vanished` is `false`.
 
+The last keyword is `retract_keys = true` which will "retract" keys (i.e., make the
+integers smaller integers) so that all unique IDs
+are the 1-incremented positive integers. E.g., if the IDs where 1, 6, 8, they will become
+1, 2, 3. The special id -1 is unaffected by this.
+
 
     rematch_continuation!(attractors_info::Vector{<:Dict}; kwargs...)
 
@@ -200,18 +205,20 @@ function match_continuation!(attractors_info; kwargs...)
 end
 function match_continuation!(
         fractions_curves::Vector{<:Dict}, attractors_info::Vector{<:Dict};
-        threshold = Inf, use_vanished = !isinf(threshold), kwargs...
+        threshold = Inf, use_vanished = !isinf(threshold), retract_keys = true, kwargs...
     )
     if !use_vanished
         _rematch_ignored!(fractions_curves, attractors_info; threshold, kwargs...)
     else
         _rematch_with_past!(fractions_curves, attractors_info; threshold, kwargs...)
     end
-    # This part normalizes so that keys increment by +1
-    rmap = retract_keys_to_consecutive(fractions_curves)
-    for (da, df) in zip(attractors_info, fractions_curves)
-        swap_dict_keys!(da, rmap)
-        swap_dict_keys!(df, rmap)
+    if retract_keys
+        # This part normalizes so that keys increment by +1
+        rmap = retract_keys_to_consecutive(fractions_curves)
+        for (da, df) in zip(attractors_info, fractions_curves)
+            swap_dict_keys!(da, rmap)
+            swap_dict_keys!(df, rmap)
+        end
     end
 end
 

--- a/src/continuation/match_attractor_ids.jl
+++ b/src/continuation/match_attractor_ids.jl
@@ -72,7 +72,7 @@ function replacement_map(a₊::Dict, a₋::Dict;
     replacement_map(keys₊, keys₋, distances::Dict, threshold, nextid)
 end
 
-function replacement_map(keys₊, keys₋, distances::Dict, threshold, next_id)
+function replacement_map(keys₊, keys₋, distances::Dict, threshold, next_id = max(maximum(keys₊), maximum(keys₋)) + 1)
     # Transform distances to sortable collection. Sorting by distance
     # ensures we prioritize the closest matches
     sorted_keys_with_distances = Tuple{Int, Int, Float64}[]
@@ -167,7 +167,7 @@ end
     match_continuation!(fractions_curves::Vector{<:Dict}, attractors_info::Vector{<:Dict}; kwargs...)
 
 Given the outputs of [`continuation`](@ref) with [`RecurrencesFindAndMatch`](@ref),
-perform the matching step of the process again with the (possibly different) keywords
+perform the matching step of the process with the (possibly different) keywords
 that [`match_statespacesets!`](@ref) accepts. This "re-matching" is possible because in
 [`continuation`](@ref) finding the attractors and their basins is a completely independent
 step from matching them with their IDs in the previous parameter value.
@@ -180,16 +180,14 @@ step from matching them with their IDs in the previous parameter value.
 
     rematch_continuation!(attractors_info::Vector{<:Dict}; kwargs...)
 
-This is a convenience method that only uses and modifies the attractors container.
+This is a convenience method that only uses and modifies the state space set container
+without the need for a basins fractions container.
 """
 function match_continuation!(attractors_info; kwargs...)
-    fractions_curves = [d => Dict(k => false for k in keys(d)) for d in attractors_info]
-    rematch_continuation!(fractions_curves, attractors_info; kwargs...)
+    fractions_curves = [Dict(k => nothing for k in keys(d)) for d in attractors_info]
+    match_continuation!(fractions_curves, attractors_info; kwargs...)
 end
 function match_continuation!(fractions_curves, attractors_info; used_vanished = false, kwargs...)
-    if isnothing(fractions_curves)
-        fractions_curves = [d => Dict(k => false for k in keys(d)) for d in attractors_info]
-    end
     if !used_vanished
         _rematch_ignored!(fractions_curves, attractors_info; kwargs...)
     else

--- a/src/continuation/match_attractor_ids.jl
+++ b/src/continuation/match_attractor_ids.jl
@@ -169,7 +169,7 @@ end
 Loop over all entries in the given arguments (which are typically the direct outputs of
 [`continuation`](@ref) with [`RecurrencesFindAndMatch`](@ref)), and match the
 attractor IDs in both the attractors container and the basins fractions container.
-This means that we loop over each entry of the vectors (besides the first),
+This means that we loop over each entry of the vectors (skipping the first),
 and in each entry we attempt to match the dictionary keys to the keys of the
 previous dictionary using [`match_statespacesets`](@ref).
 

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -18,4 +18,8 @@ end
 @deprecate GroupAcrossParameterContinuation FeaturizeGroupAcrossParameter
 @deprecate match_attractor_ids! match_statespacesets!
 @deprecate GroupAcrossParameter FeaturizeGroupAcrossParameter
-@deprecate rematch! rematch_continuation!
+@deprecate rematch! match_continuation!
+
+function match_statespacesets!(as::Vector{<:Dict}; kwargs...)
+    error("This function was incorrect. Use `match_continuation!` instead.")
+end

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -18,3 +18,4 @@ end
 @deprecate GroupAcrossParameterContinuation FeaturizeGroupAcrossParameter
 @deprecate match_attractor_ids! match_statespacesets!
 @deprecate GroupAcrossParameter FeaturizeGroupAcrossParameter
+@deprecate rematch! rematch_continuation!

--- a/src/mapping/grouping/cluster_optimal_ϵ.jl
+++ b/src/mapping/grouping/cluster_optimal_ϵ.jl
@@ -80,7 +80,7 @@ function optimal_radius_dbscan_silhouette(features, min_neighbors, metric,
     # vary ϵ to find the best one (which will maximize the mean sillhoute)
     dists = pairwise(metric, features)
     for i in eachindex(ϵ_grid)
-        clusters = dbscan(dists, ϵ_grid[i], min_neighbors)
+        clusters = dbscan(dists, ϵ_grid[i]; min_neighbors)
         sils = silhouettes_new(clusters, dists)
         s_grid[i] = silhouette_statistic(sils)
     end
@@ -118,7 +118,7 @@ function optimal_radius_dbscan_silhouette_optim(
 end
 
 function silhouettes_from_distances(ϵ, dists, min_neighbors, silhouette_statistic=mean)
-    clusters = dbscan(dists, ϵ, min_neighbors)
+    clusters = dbscan(dists, ϵ; min_neighbors)
     sils = silhouettes_new(clusters, dists)
     # We return minus here because Optim finds minimum; we want maximum
     return -silhouette_statistic(sils)

--- a/src/mapping/grouping/cluster_optimal_ϵ.jl
+++ b/src/mapping/grouping/cluster_optimal_ϵ.jl
@@ -80,7 +80,7 @@ function optimal_radius_dbscan_silhouette(features, min_neighbors, metric,
     # vary ϵ to find the best one (which will maximize the mean sillhoute)
     dists = pairwise(metric, features)
     for i in eachindex(ϵ_grid)
-        clusters = dbscan(dists, ϵ_grid[i]; min_neighbors)
+        clusters = dbscan(dists, ϵ_grid[i], min_neighbors)
         sils = silhouettes_new(clusters, dists)
         s_grid[i] = silhouette_statistic(sils)
     end
@@ -118,7 +118,7 @@ function optimal_radius_dbscan_silhouette_optim(
 end
 
 function silhouettes_from_distances(ϵ, dists, min_neighbors, silhouette_statistic=mean)
-    clusters = dbscan(dists, ϵ; min_neighbors)
+    clusters = dbscan(dists, ϵ, min_neighbors)
     sils = silhouettes_new(clusters, dists)
     # We return minus here because Optim finds minimum; we want maximum
     return -silhouette_statistic(sils)

--- a/src/mapping/grouping/cluster_optimal_ϵ.jl
+++ b/src/mapping/grouping/cluster_optimal_ϵ.jl
@@ -80,7 +80,7 @@ function optimal_radius_dbscan_silhouette(features, min_neighbors, metric,
     # vary ϵ to find the best one (which will maximize the mean sillhoute)
     dists = pairwise(metric, features)
     for i in eachindex(ϵ_grid)
-        clusters = dbscan(dists, ϵ_grid[i], min_neighbors)
+        clusters = dbscan(dists, ϵ_grid[i]; min_neighbors, metric = nothing)
         sils = silhouettes_new(clusters, dists)
         s_grid[i] = silhouette_statistic(sils)
     end
@@ -118,7 +118,7 @@ function optimal_radius_dbscan_silhouette_optim(
 end
 
 function silhouettes_from_distances(ϵ, dists, min_neighbors, silhouette_statistic=mean)
-    clusters = dbscan(dists, ϵ, min_neighbors)
+    clusters = dbscan(dists, ϵ; min_neighbors, metric = nothing)
     sils = silhouettes_new(clusters, dists)
     # We return minus here because Optim finds minimum; we want maximum
     return -silhouette_statistic(sils)

--- a/test/continuation/matching_attractors.jl
+++ b/test/continuation/matching_attractors.jl
@@ -60,6 +60,28 @@ end
     @test haskey(allatts2[1], 2)
 end
 
+@testset "continuation matching advanced" begin
+    jrange = 0.1:0.1:1
+    allatts = [Dict(1 => [SVector(0.0, 0.0)], 2 => [SVector(j, j)], 3 => [SVector(j, 0)]) for j in jrange]
+    allatts = [Dict(keys(d) .=> StateSpaceSet.(values(d))) for d in allatts]
+    # delete attractors every other parameter
+    for i in eachindex(jrange)
+        if iseven(i)
+            delete!(allatts[i], 3)
+        end
+    end
+
+    @testset "ignore vanished" begin
+        atts = deepcopy(allatts)
+        match_continuation!(atts; use_vanished = false)
+        # After the first 3 key, all subsequent keys 3 become the next integer,
+        # and since we started cutting away keys 3 from `i = 2` we have
+        # 4 extra 3 keys to add
+        @test unique_keys(atts) == 1:7
+    end
+
+end
+
 
 if DO_EXTENSIVE_TESTS
     @testset "magnetic pendulum" begin

--- a/test/continuation/matching_attractors.jl
+++ b/test/continuation/matching_attractors.jl
@@ -62,7 +62,7 @@ end
 
 @testset "continuation matching advanced" begin
     jrange = 0.1:0.1:1
-    allatts = [Dict(1 => [SVector(0.0, 0.0)], 2 => [SVector(j, j)], 3 => [SVector(j, 0)]) for j in jrange]
+    allatts = [Dict(1 => [SVector(0.0, 0.0)], 2 => [SVector(1.0, 1.0)], 3 => [SVector((10j)^2, 0)]) for j in jrange]
     allatts = [Dict(keys(d) .=> StateSpaceSet.(values(d))) for d in allatts]
     # delete attractors every other parameter
     for i in eachindex(jrange)
@@ -80,6 +80,37 @@ end
         @test unique_keys(atts) == 1:7
     end
 
+    @testset "use vanished" begin
+        @testset "Inf thresh" begin
+            atts = deepcopy(allatts)
+            match_continuation!(atts; use_vanished = true)
+            @test unique_keys(atts) == 1:3
+            for i in eachindex(jrange)
+                if iseven(i)
+                    @test sort!(collect(keys(atts[i]))) == 1:2
+                else
+                    @test sort!(collect(keys(atts[i]))) == 1:3
+                end
+            end
+        end
+        @testset "finite thresh" begin
+            # okay here we test the case that the trehsold becomes too large
+            threshold = 10.0 # at the 5th index, we cannot match anymore
+            atts = deepcopy(allatts)
+            match_continuation!(atts; use_vanished = true, threshold)
+            @testset "i=$(i)" for i in eachindex(jrange)
+                if iseven(i)
+                    @test sort!(collect(keys(atts[i]))) == 1:2
+                else
+                    if i < 5
+                        @test sort!(collect(keys(atts[i]))) == 1:3
+                    else
+                        @test sort!(collect(keys(atts[i]))) == [1, 2, i÷2 + 2]
+                    end
+                end
+            end
+        end
+    end
 end
 
 

--- a/test/continuation/matching_attractors.jl
+++ b/test/continuation/matching_attractors.jl
@@ -32,7 +32,7 @@ DO_EXTENSIVE_TESTS = get(ENV, "ATTRACTORS_EXTENSIVE_TESTS", "false") == "true"
     end
 end
 
-@testset "matching attractors in vector" begin
+@testset "continuation matching" begin
     # Make fake attractors with points that become more "separated" as "parameter"
     # is increased
     jrange = 0.1:0.1:1
@@ -46,26 +46,18 @@ end
         end
     end
     # Test with distance not enough to increment
-    match_statespacesets!(allatts; threshold = 100.0) # all odd keys become 1
+    match_continuation!(allatts; threshold = 100.0) # all odd keys become 1
     @test all(haskey(d, 1) for d in allatts)
     @test all(haskey(d, 2) for d in allatts)
     # Test with distance enough to increment
     allatts2 = deepcopy(allatts)
-    match_statespacesets!(allatts2; threshold = 0.1) # all keys there were `2` get incremented
+    match_continuation!(allatts2; threshold = 0.1) # all keys there were `2` get incremented
     @test all(haskey(d, 1) for d in allatts2)
     for i in 2:length(jrange)
         @test haskey(allatts2[i], i+1)
         @test !haskey(allatts2[i], 2)
     end
     @test haskey(allatts2[1], 2)
-    # Test rematch function
-    allatts3 = deepcopy(allatts2)
-    fracs = [Dict(k => 0.5 for (k, v) in att) for att in allatts3]
-    @test unique_keys(fracs) == 1:11
-    # Same matching as in `allatts`
-    rematch!(fracs, allatts3; threshold = 100.0)
-    @test unique_keys(fracs) == 1:2
-    @test unique_keys(allatts3) == 1:2
 end
 
 

--- a/test/mfs/mfstest.jl
+++ b/test/mfs/mfstest.jl
@@ -76,7 +76,7 @@ end
 struct MagneticPendulum
     magnets::Vector{SVector{2, Float64}}
 end
-mutable struct MagneticPendulumParams
+mutable struct MagneticPendulumParams2
     γs::Vector{Float64}
     d::Float64
     α::Float64
@@ -100,7 +100,7 @@ end
 function magnetic_pendulum(u = [sincos(0.12553*2π)..., 0, 0];
     γ = 1.0, d = 0.3, α = 0.2, ω = 0.5, N = 3, γs = fill(γ, N))
     m = MagneticPendulum([SVector(cos(2π*i/N), sin(2π*i/N)) for i in 1:N])
-    p = MagneticPendulumParams(γs, d, α, ω)
+    p = MagneticPendulumParams2(γs, d, α, ω)
     return CoupledODEs(m, u, p)
 end
 


### PR DESCRIPTION
This re-works the way matching works in `RAFM` to account for a _crucial mistake_. Previously, if an attractor dissapeared, and a new one appeared later, then they would both be assigned the same ID even though they would have never been compared with each other. 

This new continuation matching allows for two options:

1. Never compare vanished attractors, but still ensure that they get different ids
2. Compare vanished attractors by keeping track of their latest ghosts, and do the formal matching with the ghosts and new attractors

@kalelR this should be highly relevant for you if you use `RAFM` in scientific work.

@kalelR or @awage please review.