### PR TITLE
Rework clustering src to return ε and optimal silhuette value

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Attractors"
 uuid = "f3fd9213-ca85-4dba-9dfd-7fc91308fec7"
 authors = ["George Datseris <datseris.george@gmail.com>", "Kalel Rossi", "Alexandre Wagemakers"]
 repo = "https://github.com/JuliaDynamics/Attractors.jl.git"
-version = "1.9.0"
+version = "1.9.1"
 
 [deps]
 BlackBoxOptim = "a134a8b2-14d6-55f6-9291-3336d3ab0209"

--- a/src/mapping/grouping/cluster_config.jl
+++ b/src/mapping/grouping/cluster_config.jl
@@ -15,7 +15,7 @@ The defaults are a significant improvement over existing literature, see Descrip
 ## Keyword arguments
 
 * `clust_distance_metric = Euclidean()`: A metric to be used in the clustering.
-  It can be any function `f(a, b)` that returns the distance between vectors
+  It can be any function `f(a, b)` that returns the distance between real-valued vectors
   `a, b`. All metrics from Distances.jl can be used here.
 * `rescale_features = true`: if true, rescale each dimension of the extracted features
   separately into the range `[0,1]`. This typically leads to more accurate clustering.
@@ -157,8 +157,8 @@ function _distance_matrix(features, config::GroupViaClustering;
     else # it is any arbitrary distance function, e.g., used in aggregating attractors
         @inbounds for i in eachindex(features)
             Threads.@threads for j in i:length(features)
-                dists[i, j] = metric(features[i], features[j])
-                dists[j, i] = dists[i, j] # symmetry
+                v = metric(features[i], features[j])
+                dists[i, j] = dists[j, i] = v # utilize symmetry
             end
         end
     end

--- a/src/mapping/grouping/cluster_config.jl
+++ b/src/mapping/grouping/cluster_config.jl
@@ -57,6 +57,7 @@ The defaults are a significant improvement over existing literature, see Descrip
   attraction).
 
 ## Description
+
 The DBSCAN clustering algorithm is used to automatically identify clusters of similar
 features. Each feature vector is a point in a feature space. Each cluster then basically
 groups points that are closely packed together. Closely packed means that the points have
@@ -66,6 +67,7 @@ task. Currently, three methods are implemented to automatically estimate an "opt
 radius.
 
 ### Estimating the optimal radius
+
 The default method is the **silhouettes method**, which includes keywords `silhouette` and
 `silhouette_optim`. Both of them search for the radius that optimizes the clustering,
 meaning the one that maximizes a statistic `silhouette_statistic` (e.g. mean value) of a
@@ -169,7 +171,6 @@ function _distance_matrix(features, config::GroupViaClustering;
             # Instead of going over all `j` we go over `(k+1)` to end,
             # and also add value to transpose. (also assume that if j=k, distance is 0)
             for j in (k+1):size(dists, 1)
-                # TODO: Shouldn't we use `metric` here instead of `abs`?
                 pdist = par_weight*abs(par_vector[k] - par_vector[j])
                 dists[k,j] += pdist
                 dists[j,k] += pdist
@@ -184,12 +185,14 @@ function _extract_ϵ_optimal(features, config::GroupViaClustering)
     num_attempts_radius, silhouette_statistic, max_used_features) = config
 
     if optimal_radius_method isa String
+        # subsample features to accelerate optimal radius search
         if max_used_features == 0 || max_used_features > length(features)
             features_for_optimal = features
         else
             features_for_optimal = sample(features, max_used_features; replace = false)
         end
-        ϵ_optimal = optimal_radius_dbscan(
+        # get optimal radius (function dispatches on the radius method)
+        ϵ_optimal, v_optimal = optimal_radius_dbscan(
             features_for_optimal, min_neighbors, clust_distance_metric,
             optimal_radius_method, num_attempts_radius, silhouette_statistic
         )


### PR DESCRIPTION
This PR does not change any API; only modifies internal source code so that some internal functions return both optimal radius and optimal value.

I require this as I progress through #85