### PR TITLE
Make `AttractorsViaRecurrences` more simple when finding and storing attractors

### DIFF
--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -323,7 +323,9 @@ axislegend(ax)
 
 fig
 ```
+
 ## Subdivision Based Grid for `AttractorsViaRecurrences`
+
 To achieve even better results for this kind of problematic systems than with previuosly introduced `Irregular Grids`  we provide a functionality to construct `Subdivision Based Grids` in which
 one can obtain more coarse or dense structure not only along some axis but for a specific regions where the state space flow has
 significantly different speed. [`subdivided_based_grid`](@ref) enables automatic evaluation of velocity vectors for regions of originally user specified

--- a/ext/plotting.jl
+++ b/ext/plotting.jl
@@ -259,7 +259,8 @@ function Attractors.animate_attractors_continuation(
 
     # setup fractions axis
     heights = Observable(fill(0.1, K))
-    barplot!(fracax, fill(0.5, K), heights; width = 1, gap = 0, stack=1:K, color = colors)
+    barcolors = [colors[k] for k in ukeys]
+    barplot!(fracax, fill(0.5, K), heights; width = 1, gap = 0, stack=1:K, color = barcolors)
 
     record(fig, savename, eachindex(prange); framerate) do i
         p = prange[i]

--- a/src/continuation/continuation_recurrences.jl
+++ b/src/continuation/continuation_recurrences.jl
@@ -26,8 +26,8 @@ of the `mapper`. Seeding initial conditions close to previous attractors acceler
 the main bottleneck of [`AttractorsViaRecurrences`](@ref), which is finding the attractors.
 
 After the special initial conditions are mapped to attractors, attractor basin fractions
-are computed by sampling random initial conditions.
-(using the provided `sampler` in [`continuation`](@ref)) and mapping them to attractors
+are computed by sampling random initial conditions using the provided `sampler` in
+[`continuation`](@ref)) and mapping them to attractors
 using the [`AttractorsViaRecurrences`](@ref) mapper.
 I.e., exactly as in [`basins_fractions`](@ref).
 Naturally, during this step new attractors may be found, besides those found
@@ -36,18 +36,21 @@ Once the basins fractions are computed,
 the parameter is incremented again and we perform the steps as before.
 
 This process continues for all parameter values. After all parameters are exhausted,
-the newly found attractors (and their fractions) are "matched" to the previous ones.
-I.e., their _IDs are changed_, so that attractors with closest distance to those at a
+the found attractors (and their fractions) are "matched" to the previous ones.
+I.e., their _IDs are changed_, so that attractors that are "similar" to those at a
 previous parameter get assigned the same ID.
-Matching is rather sophisticated and is described in
+Matching is rather sophisticated and is described in detail in
 [`match_statespacesets!`](@ref) and [`match_continuation!`](@ref).
-Typically, the matching process matches attractor IDs that are closest in state space
+By default the matching process matches attractor IDs that are closest in state space
 distance, but more options are possible, see [`match_statespacesets!`](@ref).
+By default attractors that dissapear and later re-appear get assigned different IDs,
+use `use_vanished = true` for the alternative.
 
 Note that in this continuation the finding-attractors and matching-attractors
 steps are completely independent. This means, that if you don't like the initial
 outcome of the matching process, you may call [`match_continuation!`](@ref) again
 on the outcome with (possibly different) matching-related keywords.
+You do not need to compute attractors and basins again!
 
 ## Keyword arguments
 
@@ -91,7 +94,7 @@ function _default_seeding_process_10(attractor::AbstractStateSpaceSet; rng = Mer
 end
 
 # This is the one used
-function _default_seeding_process(attractor::AbstractStateSpaceSet; rng = MersenneTwister(1))
+function _default_seeding_process(attractor::AbstractStateSpaceSet)
     return (attractor[1],) # must be iterable
 end
 

--- a/src/continuation/match_attractor_ids.jl
+++ b/src/continuation/match_attractor_ids.jl
@@ -194,7 +194,7 @@ are the 1-incremented positive integers. E.g., if the IDs where 1, 6, 8, they wi
 1, 2, 3. The special id -1 is unaffected by this.
 
 
-    rematch_continuation!(attractors_info::Vector{<:Dict}; kwargs...)
+    match_continuation!(attractors_info::Vector{<:Dict}; kwargs...)
 
 This is a convenience method that only uses and modifies the state space set dictionary
 container without the need for a basins fractions container.

--- a/src/continuation/match_attractor_ids.jl
+++ b/src/continuation/match_attractor_ids.jl
@@ -226,6 +226,8 @@ function _rematch_ignored!(fractions_curves, attractors_info; kwargs...)
     next_id = 1
     for i in 1:length(attractors_info)-1
         a₊, a₋ = attractors_info[i+1], attractors_info[i]
+        # If there are no attractors, skip the matching
+        (isempty(a₊) || isempty(a₋)) && continue
         # Here we always compute a next id. In this way, if an attractor dissapears
         # and re-appears, it will get a different (incremented) id as it should!
         next_id_a = max(maximum(keys(a₊)), maximum(keys(a₋))) + 1

--- a/src/mapping/attractor_mapping_proximity.jl
+++ b/src/mapping/attractor_mapping_proximity.jl
@@ -9,17 +9,15 @@ The system gets stepped, and at each step the minimum distance to all
 attractors is computed. If any of these distances is `< ε`, then the label of the nearest
 attractor is returned.
 
-If an `ε::Real` is _not_ provided by the user, a value is computed
+If an `ε::Real` is not provided by the user, a value is computed
 automatically as half of the minimum distance between all attractors.
-This operation can be expensive for large attractor StateSpaceSets.
+This operation can be expensive for large `StateSpaceSet`s.
 If `length(attractors) == 1`, then `ε` becomes 1/10 of the diagonal of the box containing
 the attractor. If `length(attractors) == 1` and the attractor is a single point,
 an error is thrown.
 
-Because in this method the attractors are already known to the user,
-the method can also be called _supervised_.
-
 ## Keywords
+
 * `Ttr = 100`: Transient time to first evolve the system for before checking for proximity.
 * `Δt = 1`: Step time given to `step!`.
 * `horizon_limit = 1e3`: If the maximum distance of the trajectory from any of the given
@@ -84,7 +82,7 @@ function _deduce_ε_from_attractors(attractors, search_trees, verbose = false)
                 end
             end
         end
-        @info("Minimum distance between attractors computed: $(minε)")
+        verbose && @info("Minimum distance between attractors computed: $(minε)")
         ε = minε/2
     else
         attractor = first(attractors)[2] # get the single attractor

--- a/src/mapping/recurrences/attractor_mapping_recurrences.jl
+++ b/src/mapping/recurrences/attractor_mapping_recurrences.jl
@@ -55,13 +55,14 @@ want to search for attractors in a lower dimensional subspace.
 
 ### Finite state machine configuration
 
-* `mx_chk_fnd_att = 1000`: Number of consecutive visits to previously visited
-  unlabeled cells required before declaring we have converged to a new attractor.
+* `mx_chk_fnd_att = 100`: Number of consecutive visits to previously visited
+  unlabeled cells (i.e., recurrences) required before declaring we have converged to a new attractor.
   This number tunes the accuracy of converging to attractors and should generally be high
   (and even higher for chaotic systems).
-* `mx_chk_loc_att = mx_chk_fnd_att÷10`: Number of subsequent steps taken to locate accurately the new
+* `mx_chk_loc_att = 1000`: Number of subsequent steps taken to locate accurately the new
   attractor after the convergence phase is over. Once `mx_chk_loc_att` steps have been
   taken, the new attractor has been identified with sufficient accuracy and iteration stops.
+  This number can be very high without much impact to overall performance, as this phase.
 * `store_once_per_cell = true`: Control if multiple points in state space that belong to
   the same cell are stored or not in the attractor, when a new attractor is found.
   If `true`, each visited cell will only store a point once, which is desirable for fixed

--- a/src/mapping/recurrences/attractor_mapping_recurrences.jl
+++ b/src/mapping/recurrences/attractor_mapping_recurrences.jl
@@ -2,22 +2,23 @@
 # Type definition and documentation
 #####################################################################################
 """
-    AttractorsViaRecurrences(ds::DynamicalSystem, grid::Tuple; kwargs...)
+    AttractorsViaRecurrences(ds::DynamicalSystem, grid; kwargs...)
 
 Map initial conditions of `ds` to attractors by identifying attractors on the fly based on
-recurrences in the state space, as outlined by Datseris & Wagemakers [Datseris2022](@cite).
+recurrences in the state space, as outlined in [Datseris2022](@cite).
 
 `grid` is instructions for partitioning the state space into finite-sized cells
 so that a finite state machine can operate on top of it. Possibilities are:
 
 1. A tuple of sorted `AbstractRange`s for a regular grid.
   Example is `grid = (xg, yg)` where `xg = yg = range(-5, 5; length = 100)`
-  for a two-dimensional system
+  for a two-dimensional system.
 2. A tuple of sorted `AbstractVector`s for an irregular grid, for example
-  `grid = (xg, yg)` with `xg = vcat(range(-5, -2; length = 50), range(-2, 5; length = 50)),
+  `grid = (xg, yg)` with `xg = range(0, 10.0^(1/2); length = 200).^2,
   yg = range(-5, 5; length = 100)`.
 3. An instance of the special grid type
-[`SubdividedBasedGrid`](@ref), which can be created either manually or by using [`subdivision_based_grid`](@ref).
+  [`SubdividedBasedGrid`](@ref), which can be created either manually or by using
+  [`subdivision_based_grid`](@ref).
   This automatically analyzes and adapts grid discretization
   levels in accordance with state space flow speed in different regions.
 
@@ -54,22 +55,24 @@ want to search for attractors in a lower dimensional subspace.
 
 ### Finite state machine configuration
 
-* `mx_chk_att = 2`: Μaximum checks of consecutives hits of an existing attractor cell
-  before declaring convergence to that existing attractor.
-* `mx_chk_hit_bas = 10`: Maximum check of consecutive visits of the same basin of
-  attraction before declaring convergence to an existing attractor.
-  This is ignored if `sparse = true`, as basins are not stored internally.
-* `mx_chk_fnd_att = 100`: Maximum check of consecutive visits to a previously visited
-  unlabeled cell before declaring we have found a new attractor.
-* `mx_chk_loc_att = 100`: Maximum check of consecutive visits to cells marked as a new
-  attractor, during the attractor identification phase, before declaring we that we have
-  identified the new attractor with sufficient accuracy.
+* `mx_chk_fnd_att = 1000`: Number of consecutive visits to previously visited
+  unlabeled cells required before declaring we have converged to a new attractor.
+  This number tunes the accuracy of converging to attractors and should generally be high
+  (and even higher for chaotic systems).
+* `mx_chk_loc_att = mx_chk_fnd_att÷10`: Number of subsequent steps taken to locate accurately the new
+  attractor after the convergence phase is over. Once `mx_chk_loc_att` steps have been
+  taken, the new attractor has been identified with sufficient accuracy and iteration stops.
 * `store_once_per_cell = true`: Control if multiple points in state space that belong to
-  the same cell are stored or not in the attractor, after an attractor is found.
+  the same cell are stored or not in the attractor, when a new attractor is found.
   If `true`, each visited cell will only store a point once, which is desirable for fixed
-  points and limit cycles. If `false`, at least `mx_chk_loc_att` points are
+  points and limit cycles. If `false` then `mx_chk_loc_att` points are
   stored per attractor, leading to more densely stored attractors,
   which may be desirable for instance in chaotic attractors.
+* `mx_chk_att = 2`: Μaximum checks of consecutives hits of an existing attractor cell
+  before declaring convergence to that existing attractor.
+* `mx_chk_hit_bas = 10`: Number of consecutive visits of the same basin of
+  attraction required before declaring convergence to an existing attractor.
+  This is ignored if `sparse = true`, as basins are not stored internally.
 * `mx_chk_lost = 20`: Maximum check of iterations outside the defined grid before we
   declare the orbit lost outside and hence assign it label `-1`.
 * `horizon_limit = 1e6`: If the norm of the integrator state reaches this
@@ -86,7 +89,7 @@ based on the integrator corresponding to `ds`. A recurrence in the state space m
 that the trajectory has converged to an attractor. This is the basis for finding attractors.
 
 A finite state machine (FSM) follows the
-trajectory in the state space, and constantly maps it to the given `grid`. The FSM
+trajectory in the state space, and constantly maps it to a cell in the given `grid`. The FSM
 decides when an initial condition has successfully converged into an attractor. An array,
 internally called "basins", stores the state of the FSM on the grid, according to the
 indexing system described in [Datseris2022](@cite). As the system is integrated more and more,
@@ -98,10 +101,11 @@ attraction or exit basins is utilized. In other functions like `basins_fractions
 only the attractor locations are utilized, as the basins themselves are not stored.
 
 The iteration of a given initial condition continues until one of the following happens:
+
 -  The trajectory hits `mx_chk_fnd_att` times in a row grid cells previously visited:
    it is considered that an attractor is found and is labelled with a new ID. Then,
    iteration continues a bit more until we have identified the attractor with sufficient
-   accuracy, i.e., until `mx_chk_loc_att` cells with the new ID have been visited.
+   accuracy, i.e., by taking `mx_chk_loc_att` more steps.
 -  The trajectory hits an already identified attractor `mx_chk_att` consecutive times:
    the initial condition is numbered with the attractor's ID.
 -  The trajectory hits a known basin `mx_chk_hit_bas` times in a row: the initial condition

--- a/src/mapping/recurrences/attractor_mapping_recurrences.jl
+++ b/src/mapping/recurrences/attractor_mapping_recurrences.jl
@@ -72,7 +72,7 @@ want to search for attractors in a lower dimensional subspace.
   before declaring convergence to that existing attractor.
 * `mx_chk_hit_bas = 10`: Number of consecutive visits of the same basin of
   attraction required before declaring convergence to an existing attractor.
-  This is ignored if `sparse = true`, as basins are not stored internally.
+  This is ignored if `sparse = true`, as basins are not stored internally in that case.
 * `mx_chk_lost = 20`: Maximum check of iterations outside the defined grid before we
   declare the orbit lost outside and hence assign it label `-1`.
 * `horizon_limit = 1e6`: If the norm of the integrator state reaches this

--- a/src/mapping/recurrences/attractor_mapping_recurrences.jl
+++ b/src/mapping/recurrences/attractor_mapping_recurrences.jl
@@ -97,7 +97,7 @@ trajectory in the state space, and constantly maps it to a cell in the given `gr
 The grid cells store information: they are empty, visited, basins, or attractor cells.
 The state of the FSM is decided based on the cell type and the previous state of the FSM.
 Whenever the FSM recurs its state, its internal counter is increased, otherwise it is
-reset to 0. Once the internal counter reaches a threshold, the FSM terminates.
+reset to 0. Once the internal counter reaches a threshold, the FSM terminates or changes its state.
 The possibilities for termination are the following:
 
 -  The trajectory hits `mx_chk_fnd_att` times in a row previously visited cells:

--- a/src/mapping/recurrences/attractor_mapping_recurrences.jl
+++ b/src/mapping/recurrences/attractor_mapping_recurrences.jl
@@ -106,7 +106,7 @@ The possibilities for termination are the following:
    the "attractor" information. Then iteration terminates and the initial condition is
    numbered with the attractor's ID.
 -  The trajectory hits an already identified attractor `mx_chk_att` consecutive times:
-   the initial condition is numbered with the attractor's ID.
+   the initial condition is numbered with the attractor's basin ID.
 -  The trajectory hits a known basin `mx_chk_hit_bas` times in a row: the initial condition
    belongs to that basin and is numbered accordingly. Notice that basins are stored and
    used only when `sparse = false` otherwise this clause is ignored.

--- a/src/mapping/recurrences/attractor_mapping_recurrences.jl
+++ b/src/mapping/recurrences/attractor_mapping_recurrences.jl
@@ -64,7 +64,7 @@ want to search for attractors in a lower dimensional subspace.
 * `mx_chk_loc_att = 1000`: Number of subsequent steps taken to locate accurately the new
   attractor after the convergence phase is over. Once `mx_chk_loc_att` steps have been
   taken, the new attractor has been identified with sufficient accuracy and iteration stops.
-  This number can be very high without much impact to overall performance, as this phase.
+  This number can be very high without much impact to overall performance.
 * `store_once_per_cell = true`: Control if multiple points in state space that belong to
   the same cell are stored or not in the attractor, when a new attractor is found.
   If `true`, each visited cell will only store a point once, which is desirable for fixed
@@ -96,11 +96,11 @@ A finite state machine (FSM) follows the
 trajectory in the state space, and constantly maps it to a cell in the given `grid`.
 The grid cells store information: they are empty, visited, basins, or attractor cells.
 The state of the FSM is decided based on the cell type and the previous state of the FSM.
-Whenever the FSM re-occurs its state, its internal counter is increased, otherwise it is
+Whenever the FSM recurs its state, its internal counter is increased, otherwise it is
 reset to 0. Once the internal counter reaches a threshold, the FSM terminates.
 The possibilities for termination are the following:
 
--  The trajectory hits `mx_chk_fnd_att` times in a row visited cells:
+-  The trajectory hits `mx_chk_fnd_att` times in a row previously visited cells:
    it is considered that an attractor is found and is labelled with a new ID. Then,
    iteration continues for `mx_chk_loc_att` steps. Each cell visited in this period stores
    the "attractor" information. Then iteration terminates and the initial condition is
@@ -116,7 +116,7 @@ The possibilities for termination are the following:
 -  If none of the above happens, the initial condition is labelled `-1` after
    `mx_chk_safety` steps.
 
-There are some special internatal optimizations and details that we do not describe
+There are some special internal optimizations and details that we do not describe
 here but can be found in comments in the source code.
 (E.g., a special timer exists for the "lost" state which does not interrupt the main
 timer of the FSM.)

--- a/src/mapping/recurrences/finite_state_machine.jl
+++ b/src/mapping/recurrences/finite_state_machine.jl
@@ -64,7 +64,7 @@ end
 
 _possibly_reduced_state(y, ds, grid) = y
 function _possibly_reduced_state(y, ds::PoincareMap, bsn_nfo)
-    grid = bsn_nfo.grid
+    grid = bsn_nfo.grid_nfo.grid
     if ds.planecrossing.plane isa Tuple && length(grid) == dimension(ds)-1
         return y[ds.diffidxs]
     else

--- a/src/mapping/recurrences/finite_state_machine.jl
+++ b/src/mapping/recurrences/finite_state_machine.jl
@@ -275,7 +275,7 @@ function update_finite_state_machine!(bsn_nfo, ic_label)
         # since the trajectory can follow an attractor that spans outside the grid
         next_state = :lost
     elseif isodd(ic_label)
-        # hit an basin box
+        # hit an existing basin box
         next_state = :bas_hit
     end
 
@@ -296,5 +296,3 @@ function update_finite_state_machine!(bsn_nfo, ic_label)
     bsn_nfo.state = next_state
     return
 end
-
-

--- a/src/mapping/recurrences/finite_state_machine.jl
+++ b/src/mapping/recurrences/finite_state_machine.jl
@@ -232,18 +232,20 @@ function store_attractor!(bsn_nfo::BasinsInfo{D, G, Δ, T}, u) where {D, G, Δ, 
     end
 end
 
-# Notice that seting a basin index to 0 _deletes the index_ if the
-# array is a `SparseArray`, see the source code file!
 function cleanup_visited_cells!(bsn_nfo::BasinsInfo)
     old_label = bsn_nfo.visited_cell_label
+    basins = bsn_nfo.basins
     while !isempty(bsn_nfo.visited_cells)
         ind = pop!(bsn_nfo.visited_cells)
-        if bsn_nfo.basins[ind] == old_label
-            bsn_nfo.basins[ind] = 0 # 0 is the unvisited label / empty label
+        if basins[ind] == old_label
+            if basins isa SparseArray # The `if` clause is optimized away
+                delete!(basins.data, ind)
+            else # non-sparse
+                basins[ind] = 0 # 0 is the unvisited label / empty label
+            end
         end
     end
 end
-
 
 function reset_basins_counters!(bsn_nfo::BasinsInfo)
     bsn_nfo.consecutive_match = 0

--- a/src/mapping/recurrences/finite_state_machine.jl
+++ b/src/mapping/recurrences/finite_state_machine.jl
@@ -159,7 +159,7 @@ function finite_state_machine!(
             # label it and store it as part of the attractor
             bsn_nfo.basins[n] = bsn_nfo.current_att_label
             store_attractor!(bsn_nfo, u)
-        elseif even(ic_label) && ic_label != bsn_nfo.current_att_label
+        elseif even(ic_label) && ic_label ≠ bsn_nfo.current_att_label
             # Visited a cell labelled as an *existing* attractor! We have
             # attractors intersection in the grid! The algorithm can't handle this,
             # so we throw an error.
@@ -167,7 +167,7 @@ function finite_state_machine!(
             During the phase of locating a new attractor, found via sufficient recurrences,
             we encountered a cell of a previously-found attractor. This means that two
             attractors intersect in the grid, or that the precision with which we find
-            and store attractors is not fine enough. Either decrease the grid spacing,
+            and store attractors is not high enough. Either decrease the grid spacing,
             or increase `mx_chk_fnd_att` (or both).
 
             Index of cell that this occured at: $(n).

--- a/src/mapping/recurrences/finite_state_machine.jl
+++ b/src/mapping/recurrences/finite_state_machine.jl
@@ -159,7 +159,7 @@ function finite_state_machine!(
             # label it and store it as part of the attractor
             bsn_nfo.basins[n] = bsn_nfo.current_att_label
             store_attractor!(bsn_nfo, u)
-        elseif even(ic_label) && ic_label ≠ bsn_nfo.current_att_label
+        elseif iseven(ic_label) && ic_label ≠ bsn_nfo.current_att_label
             # Visited a cell labelled as an *existing* attractor! We have
             # attractors intersection in the grid! The algorithm can't handle this,
             # so we throw an error.

--- a/src/mapping/recurrences/finite_state_machine.jl
+++ b/src/mapping/recurrences/finite_state_machine.jl
@@ -261,6 +261,7 @@ function update_finite_state_machine!(bsn_nfo, ic_label)
         return
     end
 
+    # Decide the next state based on the input cell
     next_state = :undef
     if ic_label == 0 || ic_label == bsn_nfo.visited_cell_label
         # unlabeled box or previously visited box with the current label
@@ -269,24 +270,31 @@ function update_finite_state_machine!(bsn_nfo, ic_label)
         # hit an attractor box
         next_state = :att_hit
     elseif ic_label == -1
-        # out of the grid we do not reset the counter of other state
+        # out of the grid
+        # remember that when out of the grid we do not reset the counter of other state
         # since the trajectory can follow an attractor that spans outside the grid
-        bsn_nfo.state = :lost
-        return
+        next_state = :lost
     elseif isodd(ic_label)
         # hit an basin box
         next_state = :bas_hit
     end
 
+    # Take action if the state has changed.
     if next_state != current_state
-        # reset counter except in lost state (the counter freezes in this case)
-        if current_state == :lost
+        # The consecutive_match counter is reset when we switch states.
+        # However if we enter or leave  the :lost state
+        # we do not reset the counter consecutive_match
+        # since the trajectory can follow an attractor
+        # that spans outside the grid
+        if current_state == :lost || next_state == :lost
             bsn_nfo.consecutive_lost = 1
         else
             bsn_nfo.consecutive_match = 1
         end
     end
+
     bsn_nfo.state = next_state
     return
 end
+
 

--- a/src/mapping/recurrences/finite_state_machine.jl
+++ b/src/mapping/recurrences/finite_state_machine.jl
@@ -178,12 +178,13 @@ function finite_state_machine!(
         if bsn_nfo.consecutive_match ≥ mx_chk_loc_att
             # We have recorded the attractor with sufficient accuracy.
             # We now set the empty counters for the new attractor.
+            current_basin = bsn_nfo.current_att_label + 1
             cleanup_visited_cells!(bsn_nfo)
             bsn_nfo.visited_cell_label += 2
             bsn_nfo.current_att_label += 2
             reset_basins_counters!(bsn_nfo)
             # We return the label corresponding to the *basin* of the attractor
-            return ic_label + 1
+            return current_basin
         end
         return 0
     end

--- a/src/mapping/recurrences/finite_state_machine.jl
+++ b/src/mapping/recurrences/finite_state_machine.jl
@@ -92,9 +92,9 @@ The function returns `0` unless the FSM has terminated its operation.
 """
 function finite_state_machine!(
         bsn_nfo::BasinsInfo, n::CartesianIndex, u;
-        mx_chk_att = 2, mx_chk_hit_bas = 10, mx_chk_fnd_att = 100, mx_chk_loc_att = 100,
+        mx_chk_att = 2, mx_chk_hit_bas = 10, mx_chk_fnd_att = 1000, mx_chk_loc_att = mx_chk_fnd_att÷10,
         horizon_limit = 1e6, mx_chk_lost = 20, store_once_per_cell = true,
-        show_progress = true, # show_progress only used when finding new attractor.
+        show_progress = true, # show_progress can be used when finding new attractor.
     )
 
     # if n[1] == -1 means we are outside the grid,

--- a/src/mapping/recurrences/finite_state_machine.jl
+++ b/src/mapping/recurrences/finite_state_machine.jl
@@ -129,7 +129,7 @@ function finite_state_machine!(
             # also keep track of visited cells. This makes it easier to clean
             # up the basin array later!
             push!(bsn_nfo.visited_cells, n) # keep track of visited cells
-            bsn_nfo.consecutive_match = 1
+            bsn_nfo.consecutive_match = 0
         elseif ic_label == bsn_nfo.visited_cell_label
             # hit a previously visited box with the current label, possible attractor?
             bsn_nfo.consecutive_match += 1
@@ -141,7 +141,7 @@ function finite_state_machine!(
             bsn_nfo.basins[n] = bsn_nfo.current_att_label
             store_attractor!(bsn_nfo, u)
             bsn_nfo.state = :att_found
-            bsn_nfo.consecutive_match = 1
+            bsn_nfo.consecutive_match = 0
         end
         bsn_nfo.prev_label = ic_label
         return 0
@@ -194,7 +194,7 @@ function finite_state_machine!(
         if bsn_nfo.prev_label == ic_label
             bsn_nfo.consecutive_match += 1
         else
-            bsn_nfo.consecutive_match = 1
+            bsn_nfo.consecutive_match = 0
         end
         if  bsn_nfo.consecutive_match > mx_chk_hit_bas
             cleanup_visited_cells!(bsn_nfo)

--- a/src/mapping/recurrences/finite_state_machine.jl
+++ b/src/mapping/recurrences/finite_state_machine.jl
@@ -92,7 +92,7 @@ The function returns `0` unless the FSM has terminated its operation.
 """
 function finite_state_machine!(
         bsn_nfo::BasinsInfo, n::CartesianIndex, u;
-        mx_chk_att = 2, mx_chk_hit_bas = 10, mx_chk_fnd_att = 1000, mx_chk_loc_att = mx_chk_fnd_att÷10,
+        mx_chk_att = 2, mx_chk_hit_bas = 10, mx_chk_fnd_att = 1000, mx_chk_loc_att = max(10, mx_chk_fnd_att÷10),
         horizon_limit = 1e6, mx_chk_lost = 20, store_once_per_cell = true,
         show_progress = true, # show_progress can be used when finding new attractor.
     )
@@ -196,7 +196,7 @@ function finite_state_machine!(
         else
             bsn_nfo.consecutive_match = 0
         end
-        if  bsn_nfo.consecutive_match > mx_chk_hit_bas
+        if bsn_nfo.consecutive_match > mx_chk_hit_bas
             cleanup_visited_cells!(bsn_nfo)
             reset_basins_counters!(bsn_nfo)
             return ic_label

--- a/src/mapping/recurrences/finite_state_machine.jl
+++ b/src/mapping/recurrences/finite_state_machine.jl
@@ -92,7 +92,7 @@ The function returns `0` unless the FSM has terminated its operation.
 """
 function finite_state_machine!(
         bsn_nfo::BasinsInfo, n::CartesianIndex, u;
-        mx_chk_att = 2, mx_chk_hit_bas = 10, mx_chk_fnd_att = 1000, mx_chk_loc_att = max(10, mx_chk_fnd_att÷10),
+        mx_chk_att = 2, mx_chk_hit_bas = 10, mx_chk_fnd_att = 100, mx_chk_loc_att = 1000,
         horizon_limit = 1e6, mx_chk_lost = 20, store_once_per_cell = true,
         show_progress = true, # show_progress can be used when finding new attractor.
     )

--- a/src/mapping/recurrences/grids.jl
+++ b/src/mapping/recurrences/grids.jl
@@ -18,9 +18,10 @@ end
 minmax_grid_extent(g::RegularGrid) = g.grid_minima, g.grid_maxima
 mean_cell_diagonal(g::RegularGrid{D}) where {D} = norm(g.grid_steps)
 
-struct IrregularGrid{D} <: Grid
-    grid::NTuple{D, Vector{Float64}}
+struct IrregularGrid{D, T <: Tuple} <: Grid
+    grid::T
 end
+IrregularGrid(tuple::T) where {T} = IrregularGrid{length(tuple), T}(tuple)
 minmax_grid_extent(g::IrregularGrid) = minmax_grid_extent(g.grid)
 
 minmax_grid_extent(g::NTuple) = map(minimum, g), map(maximum, g)

--- a/src/mapping/recurrences/sparse_arrays.jl
+++ b/src/mapping/recurrences/sparse_arrays.jl
@@ -51,11 +51,7 @@ Base.@propagate_inbounds Base.getindex(a::SparseArray{T,N}, I::Vararg{Int,N}) wh
                                         getindex(a, CartesianIndex(I))
 
 @inline function Base.setindex!(a::SparseArray{T,N}, v, I::CartesianIndex{N}) where {T,N}
-    if v != zero(T)
-        a.data[I] = v
-    else
-        delete!(a.data, I) # does not do anything if there was no key corresponding to I
-    end
+    a.data[I] = v
     return v
 end
 Base.@propagate_inbounds function Base.setindex!(

--- a/test/continuation/aggregate_attractors.jl
+++ b/test/continuation/aggregate_attractors.jl
@@ -1,2 +1,0 @@
-# TODO: Will write tests here after Alex finishes his proposal PR
-# or discussion on whether the interface can be further simplified

--- a/test/continuation/recurrences_continuation.jl
+++ b/test/continuation/recurrences_continuation.jl
@@ -189,7 +189,7 @@ if DO_EXTENSIVE_TESTS
 @testset "Henon map" begin
     henon_rule(x, p, n) = SVector{2}(1.0 - p[1]*x[1]^2 + x[2], p[2]*x[1])
     ds = DeterministicIteratedMap(henon_rule, zeros(2), [1.4, 0.3])
-    psorig = range(1.2, 1.25; length = 101)
+    ps = range(1.2, 1.25; length = 101)
     # In these parameters we go from a chaotic attractor to a period 7 orbit at a≈1.2265
     # (you can see this by launching our wonderful `interactive_orbitdiagram` app).
     # So we can use this to test different matching processes
@@ -217,7 +217,6 @@ if DO_EXTENSIVE_TESTS
     rsc = RecurrencesFindAndMatch(mapper;
         threshold = 0.99, distance = distance_function
     )
-    ps = psorig
     fractions_curves, attractors_info = continuation(
         rsc, ps, pidx, sampler;
         show_progress = false, samples_per_parameter = 100
@@ -236,39 +235,15 @@ if DO_EXTENSIVE_TESTS
 
     # unique keys
     ukeys = Attractors.unique_keys(attractors_info)
-    # We must have 4 attractors: initial chaotic, period 14 in the middle,
+
+    # We must have 3 attractors: initial chaotic, period 14 in the middle,
     # chaotic again, and period 7 at the end. ALl of these should be matched to each other.
-    # Since we retract keys, we have 1:4
-    @test ukeys == 1:4
+    # Notice that due to the storage of "ghost" attractors in `RAFM`, the
+    # first and second chaotic attractors are mapped to each other.
+    @test ukeys == 1:3
 
     # # Animation of henon attractors
-    # using GLMakie
-    # fig = Figure(); display(fig)
-    # ax = Axis(fig[1,1]; limits = (-2,2,-1,1))
-    # colors = Dict(k => Cycled(i) for (i, k) in enumerate(ukeys))
-    # att_obs = Dict(k => Observable(Point2f[]) for k in ukeys)
-    # for k in ukeys
-    #     scatter!(ax, att_obs[k]; color = colors[k],
-    #     label = "$k", markersize = 8)
-    # end
-    # axislegend(ax)
-    # display(fig)
-    # record(fig, "henon_test.mp4", eachindex(ps); framerate = 5) do i
-    #     p = ps[i]
-    #     ax.title = "p = $p"
-    #     # fs = fractions_curves[i]
-    #     attractors = attractors_info[i]
-    #     set_parameter!(ds, pidx, p)
-    #     for (k, att) in attractors
-    #         tr = trajectory(ds, 1000, att[1]; Δt = 1)
-    #         att_obs[k][] = vec(tr)
-    #         notify(att_obs[k])
-    #     end
-    #     # also ensure that attractors that don't exist are cleared
-    #     for k in setdiff(ukeys, collect(keys(attractors)))
-    #         att_obs[k][] = Point2f[]; notify(att_obs[k])
-    #     end
-    # end
+    # animate_attractors_continuation(ds, attractors_info, fractions_curves, ps, pidx)
 end
 
 @testset "non-found attractors" begin
@@ -288,88 +263,6 @@ end
         show_progress = false, samples_per_parameter = 100
     )
     @test all(i -> isempty(i), attractors_info)
-end
-
-
-@testset "magnetic pendulum" begin
-    using PredefinedDynamicalSystems
-    d, α, ω = 0.3, 0.2, 0.5
-    ds = Systems.magnetic_pendulum(; d, α, ω)
-    xg = yg = range(-3, 3; length = 101)
-    ds = ProjectedDynamicalSystem(ds, 1:2, [0.0, 0.0])
-    mapper = AttractorsViaRecurrences(ds, (xg, yg); Δt = 1.0)
-    rr = range(1, 0; length = 101)
-    psorig = [[1, 1, γ] for γ in rr]
-    pidx = :γs
-    # important to make a sampler that respects the symmetry of the system
-    sampler, isinside = statespace_sampler(HSphere(3.0, 2), 1234)
-    for (j, ps) in enumerate((psorig, reverse(psorig)))
-        # test that both finding and removing attractor works
-        mapper = AttractorsViaRecurrences(ds, (xg, yg); sparse=false, Δt = 1.0)
-
-        continuation = RecurrencesFindAndMatch(mapper; threshold = Inf)
-        # With this threshold all attractors are mapped to each other, they are within
-        # distance 1 in state space.
-        fractions_curves, attractors_info = continuation(
-            continuation, ps, pidx, sampler; show_progress = false, samples_per_parameter = 1000
-        )
-
-        # Keys of the two attractors that always exist
-        twokeys = collect(keys(fractions_curves[(j == 2 ? 1 : 101)]))
-
-        @testset "symmetry respect" begin
-            # Initially fractions are all 0.33 but at the end only two of 0.5 remain
-            # because only two attractors remain (with equal magnetic pull)
-            startfracs, endfracs = j == 1 ? [0.33, 0.5] : [0.5, 0.33]
-            @test all(v -> isapprox(v, startfracs; atol = 1e-1), values(fractions_curves[1]))
-            @test all(v -> isapprox(v, endfracs; atol = 1e-1), values(fractions_curves[end]))
-        end
-
-        for (i, p) in enumerate(ps)
-            γ = p[3]
-            fs = fractions_curves[i]
-            attractors = attractors_info[i]
-            k = sort!(collect(keys(fs)))
-            @test maximum(k) ≤ 3
-            attk = sort!(collect(keys(attractors)))
-            @test k == attk
-            @test all(fk -> fk ∈ k, twokeys)
-
-            # It is arbitrary what id we get, because the third
-            # fixed point that vanishes could have any of the three ids
-            # But we can test for sure how many ids we have
-            # (depending on where we come from we find the attractor for longer)
-            if γ < 0.2
-                @test length(k) == 2
-            elseif γ > 0.24
-                @test length(k) == 3
-            else
-                # There is a bit of varaibility of exactly when the transition
-                # occurs, and also depends on randomness for when we get exactly 0
-                # fraction for one of the attractors
-                @test length(k) ∈ (2, 3)
-            end
-            @test sum(values(fs)) ≈ 1
-        end
-        # # Plot code for fractions
-        # using GLMakie
-        # x = [fs[finalkeys[1]] for fs in fractions_curves]
-        # y = [fs[finalkeys[2]] for fs in fractions_curves]
-        # z = zeros(length(x))
-        # fig = Figure(resolution = (400, 300))
-        # ax = Axis(fig[1,1])
-        # display(fig)
-        # γs = [p[3] for p in ps]
-        # band!(ax, γs, z, x; color = Cycled(1), label = "1")
-        # band!(ax, γs, x, x .+ y; color = Cycled(2), label  = "2")
-        # band!(ax, γs, x .+ y, 1; color = Cycled(3), label = "3")
-        # xlims!(ax, 0, 1)
-        # ylims!(ax, 0, 1)
-        # ax.ylabel = "fractions"
-        # ax.xlabel = "magnet strength"
-        # axislegend(ax)
-        # Makie.save("magnetic_fracs.png", fig; px_per_unit = 4)
-    end
 end
 
 end

--- a/test/mapping/attractor_mapping.jl
+++ b/test/mapping/attractor_mapping.jl
@@ -97,7 +97,7 @@ function test_basins(ds, u0s, grid, expected_fs_raw, featurizer;
             err = ferr, single_u_mapping = false, known_ids = [-1, 1, 2, 3]
         )
     end
-    
+
     if pairwise_comparison_matrix_test
         @testset "Featurizing, pairwise comparison, matrix features" begin
             function metric_hausdorff(A,B)
@@ -207,7 +207,7 @@ end
     function featurizer_matrix(A, t)
         return A
     end
-    
+
     test_basins(ds, u0s, grid, expected_fs_raw, featurizer; ε = 0.2, Δt = 1.0, ferr=1e-2, featurizer_matrix, pairwise_comparison_matrix_test=true, threshold_pairwise=1)
 end
 
@@ -245,9 +245,9 @@ if DO_EXTENSIVE_TESTS
             g = exp(entropy(Renyi(; q = 0), probs))
             return SVector(g, minimum(A[:,1]))
         end
-        
+
         test_basins(ds, u0s, grid, expected_fs_raw, featurizer;
-        ε = 0.01, ferr=1e-2, Δt = 0.2, mx_chk_att = 20, threshold_pairwise=100) #threshold is very high because features haven't really converged yet here
+        ε = 0.01, ferr=1e-2, Δt = 0.2, mx_chk_att = 5, Ttr = 100, threshold_pairwise=100) #threshold is very high because features haven't really converged yet here
     end
 
     @testset "Duffing oscillator: stroboscopic map" begin
@@ -309,5 +309,5 @@ if DO_EXTENSIVE_TESTS
 
         test_basins(pmap, u0s, grid, expected_fs_raw, thomas_featurizer; ε = 1.0, ferr=1e-2)
     end
-    
+
 end

--- a/test/mapping/attractor_mapping.jl
+++ b/test/mapping/attractor_mapping.jl
@@ -49,6 +49,7 @@ function test_basins(ds, u0s, grid, expected_fs_raw, featurizer;
         # @show fs
         approx_atts = extract_attractors(mapper)
         found_fs = sort(collect(values(fs)))
+        # @show found_fs
         if length(found_fs) > length(expected_fs)
             # drop -1 key if it corresponds to just unidentified points
             found_fs = found_fs[2:end]
@@ -130,7 +131,35 @@ function test_basins(ds, u0s, grid, expected_fs_raw, featurizer;
     end
 end
 
-# Actual tests
+# %% Actual tests
+@testset "Analytic dummy map" begin
+    function dumb_map(z, p, n)
+        x, y = z
+        r = p[1]
+        if r < 0.5
+            return SVector(0.0, 0.0)
+        else
+            if x ≥ 0
+                return SVector(r, r)
+            else
+                return SVector(-r, -r)
+            end
+        end
+    end
+
+    r = 1.0
+    ds = DeterministicIteratedMap(dumb_map, [0., 0.], [r])
+    u0s = [1 => [r, r], 2 => [-r, -r]] # template ics
+
+    xg = yg = range(-2.0, 2.0; length=100)
+    grid = (xg, yg)
+    expected_fs_raw = Dict(1 => 0.5, 1 => 0.5)
+    featurizer(A, t) = SVector(A[1][1])
+    test_basins(ds, u0s, grid, expected_fs_raw, featurizer;
+    max_distance = 20, ε = 1e-1, proximity_test = false, threshold_pairwise=1,
+    rerr = 1e-1, ferr = 1e-1, aerr = 1e-15)
+end
+
 @testset "Henon map: discrete & divergence" begin
     u0s = [1 => [0.0, 0.0], -1 => [0.0, 2.0]] # template ics
     henon_rule(x, p, n) = SVector{2}(1.0 - p[1]*x[1]^2 + x[2], p[2]*x[1])

--- a/test/mapping/basins_of_attraction.jl
+++ b/test/mapping/basins_of_attraction.jl
@@ -1,0 +1,31 @@
+using Attractors, Test
+
+# This is a fake bistable map that has two equilibrium points
+# for r > 0.5. It has predictable fractions.
+function dumb_map(z, p, n)
+    x, y = z
+    r = p[1]
+    if r < 0.5
+        return SVector(0.0, 0.0)
+    else
+        if x ≥ 0
+            return SVector(r, r)
+        else
+            return SVector(-r, -r)
+        end
+    end
+end
+
+r = 1.0
+ds = DeterministicIteratedMap(dumb_map, [0., 0.], [r])
+# determistic grid, we know exactly the array layout
+xg = yg = range(-1.5, 2.5; length=3)
+grid = (xg, yg)
+attrs = Dict(1 => StateSpaceSet([SVector(r, r)]), 2 => StateSpaceSet([SVector(-r, -r)]))
+mapper = AttractorsViaProximity(ds, attrs)
+
+basins, atts = basins_of_attraction(mapper, grid; show_progress=false)
+
+@test basins[1, :] == fill(2, 3)
+@test basins[2, :] == fill(1, 3)
+@test basins[3, :] == fill(1, 3)

--- a/test/mapping/irregular_grid.jl
+++ b/test/mapping/irregular_grid.jl
@@ -1,191 +1,113 @@
 using Attractors
 using Test
 
-function newton_map(z, p, n)
-    z1 = z[1] + im*z[2]
-    dz1 = newton_f(z1, p[1])/newton_df(z1, p[1])
-    z1 = z1 - dz1
-    return SVector(real(z1), imag(z1))
-end
-newton_f(x, p) = x^p - 1
-newton_df(x, p)= p*x^(p-1)
-
-ds = DiscreteDynamicalSystem(newton_map, [0.1, 0.2], [3.0])
-yg = collect(range(-1.5, 1.5; length = 400))
-xg = log.(collect(range(exp(-1.5), exp(1.5), length=400)))
-
-
-newton = AttractorsViaRecurrences(ds, (xg, yg);
-    sparse = false, mx_chk_lost = 1000, Dt =1,
-)
-
-
-@test ((newton([-0.5, 0.86]) != newton([-0.5, -0.86]))& (newton([-0.5, 0.86]) != newton([1.0, 0.0])) & (newton([-0.5, -0.86]) != newton([1.0, 0.0])))
-
-basins, attractors = basins_of_attraction(newton)
-
-@test length(attractors) == 3
-
-
-xg = vcat(range(-1.5, 0, length = 300), range(0, 1.5, length = 100))
-yg = vcat(range(-1.5, 0, length = 100), range(0, 1.5, length = 300))
-newton = AttractorsViaRecurrences(ds, (xg, yg);
-    sparse = false, mx_chk_lost = 1000, Dt = 1,
-)
-@test ((newton([-0.5, 0.86]) != newton([-0.5, -0.86]))& (newton([-0.5, 0.86]) != newton([1.0, 0.0])) & (newton([-0.5, -0.86]) != newton([1.0, 0.0])))
-basins, attractors = basins_of_attraction(newton)
-
-@test length(attractors) == 3
-
-xg = yg = range(-1.5, 1.5, length = 400)
-newton = AttractorsViaRecurrences(ds, (xg, yg);
-    sparse = false, mx_chk_lost = 1000, Dt =1,
-)
-@test ((newton([-0.5, 0.86]) != newton([-0.5, -0.86]))& (newton([-0.5, 0.86]) != newton([1.0, 0.0])) & (newton([-0.5, -0.86]) != newton([1.0, 0.0])))
-basins, attractors = basins_of_attraction(newton)
-
-@test length(attractors) == 3
-
-#########################################################################
-###                 Basin cell index test                             ###
-#########################################################################
-
-
-
-function predator_prey_fastslow(u, p, t)
-	α, γ, ϵ, ν, h, K, m = p
-	N, P = u
-    du1 = α*N*(1 - N/K) - γ*N*P / (N+h)
-    du2 = ϵ*(ν*γ*N*P/(N+h) - m*P)
-	return SVector(du1, du2)
-end
-γ = 2.5
-h = 1
-ν = 0.5
-m = 0.4
-ϵ = 1.0
-α = 0.8
-K = 15
-u0 = rand(2)
-p0 = [α, γ, ϵ, ν, h, K, m]
-ds = CoupledODEs(predator_prey_fastslow, u0, p0)
-
-
-xg = yg = range(0, 5, length = 6)
-
-grid = subdivision_based_grid(ds, (xg, yg); maxlevel = 3)
-lvl_array = grid.lvl_array
-
-@test (Attractors.basin_cell_index((2, 1.1) , grid) == CartesianIndex((17,9)))
-@test (Attractors.basin_cell_index((3.6, 2.1) , grid) == CartesianIndex((29,17)))
-@test (Attractors.basin_cell_index((4.9, 4.9) , grid) == CartesianIndex((33,33)))
-@test (Attractors.basin_cell_index((0.5, 0.5) , grid) == CartesianIndex((5,5)))
-@test (Attractors.basin_cell_index((3.4, 1.6) , grid) == CartesianIndex((27,13)))
-@test (Attractors.basin_cell_index((4.7, 2.2) , grid) == CartesianIndex((37,17)))
-
-
-
-
-############################################################
-####  SubdivisionBasedGrid tests                        ####
-############################################################
-function predator_prey_fastslow(u, p, t)
-	α, γ, ϵ, ν, h, K, m = p
-	N, P = u
-    du1 = α*N*(1 - N/K) - γ*N*P / (N+h)
-    du2 = ϵ*(ν*γ*N*P/(N+h) - m*P)
-	return SVector(du1, du2)
-end
-γ = 2.5
-h = 1
-ν = 0.5
-m = 0.4
-ϵ = 1.0
-α = 0.8
-K = 15
-u0 = rand(2)
-p0 = [α, γ, ϵ, ν, h, K, m]
-ds = CoupledODEs(predator_prey_fastslow, u0, p0)
-
-
-
-#####################
-## IrregularGrid  ###
-#####################
-attractors = []
-for pow in (1, 2)
-    xg = yg = range(0, 18.0^(1/pow); length = 200).^pow
-    mapper = AttractorsViaRecurrences(ds, (xg, yg);
-        Dt = 0.1, sparse = true,
-        mx_chk_fnd_att = 10, mx_chk_loc_att = 10,
-        mx_chk_safety = 1000,
-    )
-    sampler, _ = statespace_sampler(HRectangle(zeros(2), fill(18.0, 2)), 42)
-    fractions = basins_fractions(mapper, sampler; N = 100, show_progress = false)
-    push!(attractors, extract_attractors(mapper))
-
+function predator_prey_ds()
+    function predator_prey_fastslow(u, p, t)
+        α, γ, ϵ, ν, h, K, m = p
+        N, P = u
+        du1 = α*N*(1 - N/K) - γ*N*P / (N+h)
+        du2 = ϵ*(ν*γ*N*P/(N+h) - m*P)
+        return SVector(du1, du2)
+    end
+    γ = 2.5
+    h = 1
+    ν = 0.5
+    m = 0.4
+    ϵ = 1.0
+    α = 0.8
+    K = 15
+    u0 = rand(2)
+    p0 = [α, γ, ϵ, ν, h, K, m]
+    ds = CoupledODEs(predator_prey_fastslow, u0, p0)
+    return ds
 end
 
-@test length(vec(values(attractors)[1][1])) *10 < length(vec(values(attractors)[2][1]))
+@testset "Different grids" begin
+    @testset "Irregular grid" begin
+        # when pow = 1 we have regular grid that makes
+        # the unstable fixed point be an attractor due to trajectory slow-down
+        # The second initial condition is directly on the limit cycle
+        u0 = [9.0, 3.5]
+        u0 = [0.03, 0.5]
+        As = []
+        for pow in (1, 8)
+            ds = predator_prey_ds()
+            d = 21
+            xg = range(0, 18.0^(1/pow); length = d).^pow
+            yg = range(0, 18.0; length = d)
+            mapper = AttractorsViaRecurrences(ds, (xg, yg);
+                Dt = 0.05, sparse = true, force_non_adaptive = true,
+                mx_chk_fnd_att = 20, mx_chk_loc_att = 100,
+                store_once_per_cell = true,
+                mx_chk_safety = 1000,
+            )
+            id = mapper(u0)
+            A = extract_attractors(mapper)[1]
+            push!(As, A)
+            if pow == 1
+                @test length(A) == 1 # fixed point
+            elseif pow == 2
+                @test length(A) > 1 # limit cycle
+            end
+        end
+    end
 
+    @testset "Subdivision based grid" begin
+        u0 = [0.03, 0.5]
+        ds = predator_prey_ds()
+        xg = yg = range(0, 18; length = 21)
+        grid = (xg, yg)
+        gridsd = subdivision_based_grid(ds, (xg, yg))
+        for (i, g) in enumerate((grid, gridsd))
+            # we use the same mapper as the irregular grid (important!)
+            mapper = AttractorsViaRecurrences(ds, g;
+                Dt = 0.05, sparse = true, force_non_adaptive = true,
+                mx_chk_fnd_att = 20, mx_chk_loc_att = 100,
+                store_once_per_cell = true,
+                mx_chk_safety = 1000,
+            )
+            id = mapper(u0)
+            A = extract_attractors(mapper)[1]
+            if i == 1
+                @test length(A) == 1
+            else
+                @test length(A) > 1
+            end
+        end
+    end
+end
 
+@testset "basin cell index" begin
+    ds = predator_prey_ds()
+    xg = yg = range(0, 5, length = 6)
 
-######################
-### New approach  ####
-######################
+    grid = subdivision_based_grid(ds, (xg, yg); maxlevel = 3)
+    lvl_array = grid.lvl_array
 
+    @test (Attractors.basin_cell_index((2, 1.1) , grid) == CartesianIndex((17,9)))
+    @test (Attractors.basin_cell_index((3.6, 2.1) , grid) == CartesianIndex((29,17)))
+    @test (Attractors.basin_cell_index((4.9, 4.9) , grid) == CartesianIndex((33,33)))
+    @test (Attractors.basin_cell_index((0.5, 0.5) , grid) == CartesianIndex((5,5)))
+    @test (Attractors.basin_cell_index((3.4, 1.6) , grid) == CartesianIndex((27,13)))
+    @test (Attractors.basin_cell_index((4.7, 2.2) , grid) == CartesianIndex((37,17)))
+end
 
-xg = yg = range(0, 18, length = 30)
+@testset "automatic Δt" begin
+    ds = predator_prey_ds()
 
-grid = subdivision_based_grid(ds, (xg, yg))
+    xg = yg = range(0, 18, length = 30)
+    grid0 = (xg, yg)
+    xg = yg = range(0, 18.0^(1/2); length = 20).^2
+    grid1 = (xg, yg)
+    grid2 = SubdivisionBasedGrid(grid0, rand([0, 1, 2], (30, 30)))
 
-mapper = AttractorsViaRecurrences(ds, grid;
-        Dt = 0.1, sparse = true,
-        mx_chk_fnd_att = 10, mx_chk_loc_att = 10,
-        mx_chk_safety = 1000,
-    )
+    using Attractors: RegularGrid, IrregularGrid
 
-sampler, _ = statespace_sampler(HRectangle(zeros(2), fill(18.0, 2)), 42)
-fractions = basins_fractions(mapper, sampler; N = 100, show_progress = false)
-attractors_SBD = extract_attractors(mapper)
+    Dt0 = automatic_Δt_basins(ds, RegularGrid(grid0))
+    Dt1 = automatic_Δt_basins(ds, IrregularGrid(grid1))
+    Dt2 = automatic_Δt_basins(ds, grid2)
 
-###############################
-## same setup, regular grid  ##
-###############################
-
-xg = yg = range(0, 18, length = 30)
-mapper = AttractorsViaRecurrences(ds, (xg, yg);
-        Dt = 0.1, sparse = true,
-        mx_chk_fnd_att = 10, mx_chk_loc_att = 10,
-        mx_chk_safety = 1000,
-    )
-
-
-sampler, _ = statespace_sampler(HRectangle(zeros(2), fill(18.0, 2)), 42)
-fractions = basins_fractions(mapper, sampler; N = 100, show_progress = false)
-attractors_reg = extract_attractors(mapper)
-
-
-@test (length(vec(attractors_SBD[1]))/10) > length(vec(attractors_reg[1]))
-
-
-############################################################
-####  Automatic Δt works                                ####
-############################################################
-reinit!(ds)
-
-xg = yg = range(0, 18, length = 30)
-grid0 = (xg, yg)
-xg = yg = range(0, 18.0^(1/2); length = 20).^2
-grid1 = (xg, yg)
-grid2 = SubdivisionBasedGrid(grid0, rand([0, 1, 2], (30, 30)))
-
-using Attractors: RegularGrid, IrregularGrid
-
-Dt0 = automatic_Δt_basins(ds, RegularGrid(grid0))
-Dt1 = automatic_Δt_basins(ds, IrregularGrid(grid1))
-Dt2 = automatic_Δt_basins(ds, grid2)
-
-@test Dt0 > 0
-@test Dt1 > 0
-@test Dt2 > 0
+    @test Dt0 > 0
+    @test Dt1 > 0
+    @test Dt2 > 0
+end

--- a/test/mapping/proximity_deduce_ε.jl
+++ b/test/mapping/proximity_deduce_ε.jl
@@ -8,7 +8,7 @@ using Test
     @testset "single attractor, no ε" begin
         attractors = Dict(1 => trajectory(ds, 10000, [0.0, 0.0]; Δt = 1, Ttr=100)[1])
         mapper = AttractorsViaProximity(ds, attractors)
-        @test trunc(mapper.ε, digits = 2)  ≈ 0.18 # approximate size of attractor here
+        @test trunc(mapper.ε, digits = 2) ≈ 0.18 # approximate size of attractor here
     end
     @testset "two attractors, analytically known ε" begin
         attractors = Dict(

--- a/test/mapping/recurrence.jl
+++ b/test/mapping/recurrence.jl
@@ -84,8 +84,8 @@ end
     end
 
     @testset "Henon map: discrete & divergence" begin
-        ds = Systems.henon(zeros(2); a = 1.4, b = 0.3)
-        u0 = [0.0, 0.0]
+        henon_rule(x, p, n) = SVector{2}(1.0 - p[1]*x[1]^2 + x[2], p[2]*x[1])
+        ds = DeterministicIteratedMap(henon_rule, zeros(2), [1.4, 0.3])
         xg = yg = range(-2.0, 2.0; length=100)
         grid = (xg, yg)
         test_compatibility_sparse_nonsparse(ds, grid)

--- a/test/mapping/recurrence.jl
+++ b/test/mapping/recurrence.jl
@@ -1,4 +1,6 @@
+# This file performs more extensive tests specifically for `AttractorsViaRecurrences`
 DO_EXTENSIVE_TESTS = get(ENV, "ATTRACTORS_EXTENSIVE_TESTS", "false") == "true"
+
 
 if DO_EXTENSIVE_TESTS
 # The functionality tested here has been resolved and is only added as a test
@@ -123,4 +125,19 @@ ids = sort!(unique(basins))
 @test ids... == -1
 
 end
+
+@testset "continuing lost state" begin
+    # see discussion in https://github.com/JuliaDynamics/Attractors.jl/pull/103#issuecomment-1754617229
+    henon_rule(x, p, n) = SVector{2}(1.0 - p[1]*x[1]^2 + x[2], p[2]*x[1])
+    henon() = DeterministicIteratedMap(henon_rule, zeros(2), [1.4, 0.3])
+    ds = henon()
+    xg = yg = range(-1.0, 1.0; length=100)
+    grid = (xg, yg)
+    mapper = AttractorsViaRecurrences(ds, grid)
+    id = mapper([0. ,0.])
+    @test id == 1 # we resume going into the attractor outside the grid
+    id2 = mapper([10. ,10.])
+    @test id2 == -1 # actual divergence to infinity is still detected
+end
+
 end # extensive tests clause

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 # Additional tests may be run in this test suite according to an environment variable
 # `ATTRACTORS_EXTENSIVE_TESTS` which can be true or false.
-# If false, a small, but representative subset of tests is used.
+# If false, a smaller, but representative subset of tests is used.
 
 # ENV["ATTRACTORS_EXTENSIVE_TESTS"] = true or false (set externally)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,6 +15,7 @@ testfile(file, testname=defaultname(file)) = @testset "$testname" begin; include
         testfile("mapping/recurrence.jl")
         testfile("mapping/proximity_deduce_ε.jl")
         testfile("mapping/attractor_mapping.jl")
+        testfile("mapping/basins_of_attraction.jl")
         testfile("mapping/histogram_grouping.jl")
         testfile("mapping/irregular_grid.jl")
     end


### PR DESCRIPTION
Closes #102.

EDIT: Updated.

This PR brings many positive changes. It originally was just a simple "fix #102" but this requires much more work... Details:

- Change the recurrences algorithm to do what is described in #102. This makes the user experience simpler, as the impact of the keyword `att_loc...` is simpler and completely separated from recurrences.
- Fixes a mistake with the lost counter interrupting the main counter of the FSM.
- Fixes a bug in the animation function for making a video of attractor continuation.
- Rewrites the irregular grid tests. Now they are much smaller, and simpler, and more accurate.
- Ensures all tests pass with the latest changes, including the extensive test suite.
- Updates many docstrings to be clearer and more precise.
- Enables a new type of error handling. We can identify when two attractors intersect in the grid, and throw an error instead of letting the simulation run forever!