### PR TITLE
fix `AttractorsViaProximity` with `Inf` trajectories

### DIFF
--- a/src/mapping/attractor_mapping_proximity.jl
+++ b/src/mapping/attractor_mapping_proximity.jl
@@ -76,7 +76,7 @@ function _deduce_ε_from_attractors(attractors, search_trees, verbose = false)
                 k == m && continue
                 for p in A # iterate over all points of attractor
                     Neighborhood.NearestNeighbors.knn_point!(
-                        tree, p, false, dist, idx, Neighborhood.alwaysfalse
+                        tree, p, false, dist, idx, Neighborhood.NearestNeighbors.always_false
                     )
                     dist[1] < minε && (minε = dist[1])
                 end
@@ -109,9 +109,11 @@ function (mapper::AttractorsViaProximity)(u0; show_progress = false)
         step!(mapper.ds, mapper.Δt)
         lost_count += 1
         u = current_state(mapper.ds)
+        # first check for Inf or NaN
+        any(x -> (isnan(x) || isinf(x)), u) && return -1
         for (k, tree) in mapper.search_trees # this is a `Dict`
             Neighborhood.NearestNeighbors.knn_point!(
-                tree, u, false, mapper.dist, mapper.idx, Neighborhood.alwaysfalse
+                tree, u, false, mapper.dist, mapper.idx, Neighborhood.NearestNeighbors.always_false
             )
             if mapper.dist[1] < mapper.ε
                 return k

--- a/test/mapping/proximity_deduce_ε.jl
+++ b/test/mapping/proximity_deduce_ε.jl
@@ -25,3 +25,13 @@ using Test
         @test_throws ArgumentError AttractorsViaProximity(ds, attractors)
     end
 end
+
+@testset "Fix #61" begin
+    cubicmap(u, p, n) = SVector{1}(p[1]*u[1] - u[1]^3)
+    ds = DeterministicIteratedMap(cubicmap, [1.0], [2.0])
+    fp = [sqrt(2)]
+    attrs = Dict(1 => StateSpaceSet([fp]), 2 => StateSpaceSet([-fp]))
+    mapper = AttractorsViaProximity(ds, attrs)
+    label = mapper([2.0])
+    @test label == -1
+end


### PR DESCRIPTION
- Pre-emtivively check for Inf
- Use `always_false` from nearest neighbors for better performance
