### PR TITLE
fix #114

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@ This is the first release. It continues from ChaosTools.jl v2.9, and hence, the 
 
 ## Basin fractions continuation
 - New function `continuation` that calculates basins fractions and how these change versus a parameter (given a continuation method)
-- New basins fraction continuate method `RecurrencesFindAndMatch` that utilizes a brand new algorithm to continuate basins fractions of arbitrary systems.
+- New basins fraction continuation method `RecurrencesFindAndMatch` that utilizes a brand new algorithm to continuate basins fractions of arbitrary systems.
 - `match_attractor_ids!` has been fully overhauled to be more flexible, allow more ways to match, and also allow arbitrary user-defined ways to match.
 - New function `match_basins_ids!` for matching the output of basins_of_attraction`.
 - New exported functions `swap_dict_keys!, unique_keys, replacement_map` used in code that matches attractors and could be useful to front-end users.

--- a/src/continuation/continuation_recurrences.jl
+++ b/src/continuation/continuation_recurrences.jl
@@ -112,7 +112,7 @@ function continuation(
         error("`ics` needs to be a function.")
     end
     progress = ProgressMeter.Progress(length(prange);
-        desc="continuate basins fractions:", enabled=show_progress
+        desc="Continuating basins fractions:", enabled=show_progress
     )
 
     mapper = rsc.mapper

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,7 @@
 
 using Test
 
-defaultname(file) = uppercasefirst(replace(splittext(basename(file))[1], '_' => ' '))
+defaultname(file) = uppercasefirst(replace(splitext(basename(file))[1], '_' => ' '))
 testfile(file, testname=defaultname(file)) = @testset "$testname" begin; include(file); end
 
 @testset "Attractors.jl" begin


### PR DESCRIPTION
@<!-- -->spaette 

> these were not part of this ticket

@<!-- -->Datseris 

> word "continuation" must stay as it is

`https://docs.julialang.org/en/v1/base/file/#Base.Filesystem.splitext`

```
$ cd /tmp
$ git clone -q https://github.com/vaerksted/Attractors.jl.git
$ sed -i "s/fraction continuate/fraction continuation/g" Attractors.jl/CHANGELOG.md
$ sed -i "s/continuate/Continuating/g" \                                                         
> Attractors.jl/src/continuation/continuation_recurrences.jl
$ sed -i "s/splittext/splitext/g" Attractors.jl/test/runtests.jl
$ 
```
