### PR TITLE
Wada basins detection with the merging algorithm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v1.15
+
+- New function `test_wada_merge` to test the Wada property in 2D basins of attraction.
+- New function `haussdorff_distance` to compute distance between two binary matrices. 
+
 # v1.14
 
 - New function `edgetrack` for finding saddles.

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Attractors"
 uuid = "f3fd9213-ca85-4dba-9dfd-7fc91308fec7"
 authors = ["George Datseris <datseris.george@gmail.com>", "Kalel Rossi", "Alexandre Wagemakers"]
 repo = "https://github.com/JuliaDynamics/Attractors.jl.git"
-version = "1.14.0"
+version = "1.15.0"
 
 [deps]
 BlackBoxOptim = "a134a8b2-14d6-55f6-9291-3336d3ab0209"

--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -220,3 +220,13 @@ series = {KDD'96}
   journal={arXiv preprint arXiv:2308.16251},
   year={2023}
 }
+
+@article{Daza2018,
+  title={Ascertaining when a basin is Wada: the merging method},
+  author={Daza, Alvar and Wagemakers, Alexandre and Sanju{\'a}n, Miguel AF},
+  journal={Scientific Reports},
+  volume={8},
+  number={1},
+  pages={9954},
+  year={2018}
+}

--- a/docs/src/basins.md
+++ b/docs/src/basins.md
@@ -22,12 +22,14 @@ Several functions are provided related with analyzing the fractality of the boun
 - [`basin_entropy`](@ref)
 - [`basins_fractal_test`](@ref)
 - [`uncertainty_exponent`](@ref)
+- [`test_wada_merge`](@ref)
 
 ```@docs
 basins_fractal_dimension
 basin_entropy
 basins_fractal_test
 uncertainty_exponent
+test_wada_merge
 ```
 
 ## Edge tracking and edge states

--- a/src/basins/basins.jl
+++ b/src/basins/basins.jl
@@ -1,2 +1,3 @@
 include("basins_utilities.jl")
 include("fractality_of_basins.jl")
+include("wada_test.jl")

--- a/src/basins/wada_test.jl
+++ b/src/basins/wada_test.jl
@@ -1,148 +1,33 @@
 export test_wada_merge, haussdorff_distance
 
-# Generate all pairs of the number in ids without 
-# repetition
-function generate_pairs(ids) 
- p = Vector{Tuple{Int}}()
- for (k,n1) in enumerate(ids)
-     for (j,n2) in enumerate(ids[k+1:end])
-        push!(p,(n1,n2))
-     end
- end
- return p 
-end
 
-
-# This function returns the boundary between two basins: 
-# First we compute the distance matrix of the basins and its 
-# complementary. The pixels at distance 1 from a basin are 
-# the closest to the boundary. We compute the union the 
-# pixels computed from one basins and its complementary. 
-# We get the boundary in L1 distance!
-function get_boundary(basins::BitMatrix) 
-    bd1 = distance_matrix(basins) 
-    bdd1 = distance_matrix( .! basins) 
-    bnd = (bd1 .== 1) .| (bdd1 .== 1)
-    return bnd
-end
-
-
-# Function for L1 metric 
-w(M) = min(M[1,2]+1, M[2,1]+1, M[2,2]) 
-w2(M) = min(M[1,2]+1, M[2,1]+1, M[1,1]) 
-
-# Function for L∞ metric (Chebyshev)
-# w(M) = min(M[1,2]+1, M[2,1]+1, M[2,2], M[1,1] +1) 
-# w2(M) = min(M[1,2]+1, M[2,1]+1, M[1,1], M[2,2] +1) 
-
-# R. Shonkwilker, An image algorithm for computing the Hausdorff distance efficiently in linear time. 
-# https://doi.org/10.1016/0020-0190(89)90114-2
-# This compute the Distance transform matrix.
-# Given a matrix, we compute the distance from the 
-# basin with label 0. The result is a matrix whose 
-# entry is the distance to the closest 0 pixel in the 
-# L1 metric (Manhattan). 
-function distance_matrix(basins::BitMatrix) 
-   r,c = size(basins)
-   basdist = ones(Int32,r+2,c+2)*(r+c+4) 
-   # Assign the maximum distance to the pixels not in the basin
-   basdist[2:r+1,2:c+1] .= (1 .- basins) .*(r+c+4) 
-   # first pass right to left, up to bottom
-   for j in 2:c+1, k in 2:r+1
-       basdist[j,k] = w(view(basdist,j-1:j,k-1:k))
-    end       
-   # second pass left to right, bottom up
-   for j in c+1:-1:1, k in r+1:-1:1
-       basdist[j,k] = w2(view(basdist,j:j+1,k:k+1))
-   end       
-   # Remove the extra rows and cols necessary to the alg. 
-   return basdist[2:r+1,2:c+1]
-end
-
-
-"""
-    haussdorff_distance(M1, M2) -> hd
-
-    Compute the Hausdorff distance between two binary matrices of
-    the same size. First a distance matrix is computed using 
-    `distance_matrix` for each matrix M1 and M2. The entries
-    of this matrix are the distance in L1 metric to the 
-    closest 0 pixel in the initial matrix. The distance being 
-    0 if it belongs to the basin with id 0. 
-"""
-function haussdorff_distance(M1::BitMatrix, M2::BitMatrix)
-    bd1 = distance_matrix(M1) 
-    bd2 = distance_matrix(M2) 
-    hd1 = maximum(bd1.*M2)
-    hd2 = maximum(bd2.*M1)
-    return max(hd1,hd2)
-end
-
-# wada_fractions computes the distance between 
-# boundaries using the hausdorff distance. 
-# The distance is computed using the Shonwilker 
-# algorithm. The result is a matrix with the distance 
-# of the pixels from one boundary to the other. 
-# The algorithm returns the number of pixels
-# that are at a distance strictly more than r
-# (with the hausdorff distance). 
-function wada_fractions(bas1::BitMatrix, bas2::BitMatrix, r::Int)
-    bnd1 = get_boundary(bas1)
-    bd1 = distance_matrix(bnd1) 
-
-    bnd2 = get_boundary(bas2)
-    bd2 = distance_matrix(bnd2) 
-
-    c1 = count(bd1.*bnd2 .> r)
-    c2 = count(bd2.*bnd1 .> r)
-    # @show c1, c2
-    return max(c1,c2)./length(bnd1)
-end
-
-"""
-   merged_boundary(basins, id) -> basins
-
-Returns a matrix with two basins: the first is the basins 
-from the attractor in `id`  and the other basin is formed 
-with the union of all others basins. 
-The function returns a BitMatrix such that the basins of 
-`id` is mapped to 0 and the other basins to 1.  
-""" 
-function merged_basins(basins, id) 
-    mrg_basins = fill!(BitMatrix(undef,size(basins)), false)
-    ids = setdiff(unique(basins), id)
-    for k in ids 
-        I = findall(basins .== k)
-        mrg_basins[I] .= 1
-    end
-    return mrg_basins
-end
 
 """
     test_wada_merge(basins, r) -> p
 
-Test if the 2D array `basins` has the Wada 
-property using the merging technique of [Daza2018](@cite). 
+Test if the 2D array `basins` has the [Wada
+property](https://en.wikipedia.org/wiki/Lakes_of_Wada)
+using the merging technique of [Daza2018](@cite).
 
-## Description 
+## Description
 
-The technique consists in computing the generalized basins 
-of each attractor. These new basins are formed with on of the basins 
-and the union of the other basins. A new boundary is defined by 
-these two objects. The algorithm then computes the distance between 
-each boundaries of these basins pairwise. If all the boundaries are 
-within some distance `r`, there is a unique boundary separating 
-the basins and we have the wada property. 
-The algorithm returns the maximum proportion of pixels of a boundary 
-with distance strictly greater than `r` from another boundary. 
+The technique consists in computing the generalized basins
+of each attractor. These new basins are formed with on of the basins
+and the union of the other basins. A new boundary is defined by
+these two objects. The algorithm then computes the distance between
+each boundaries of these basins pairwise. If all the boundaries are
+within some distance `r`, there is a unique boundary separating
+the basins and we have the wada property.
+The algorithm returns the maximum proportion of pixels of a boundary
+with distance strictly greater than `r` from another boundary.
 
-If `p == 0`,  we have the Wada property for this value of `r`. 
+If `p == 0`,  we have the Wada property for this value of `r`.
 If `p > 0`, the criteria to decide if
-the basins are Wada is left to the user. Numerical inaccuracies 
+the basins are Wada is left to the user. Numerical inaccuracies
 may be responsible for a small percentage of points with distance larger than `r`
 
 """
-function test_wada_merge(basins,r) 
+function test_wada_merge(basins,r)
     ids = unique(basins)
     if length(ids) < 3
         @error "There must be at least 3 attractors"
@@ -159,3 +44,115 @@ function test_wada_merge(basins,r)
     return maximum(v)
 end
 
+"""
+    haussdorff_distance(M1, M2) -> hd
+
+    Compute the Hausdorff distance between two binary matrices of
+    the same size. First a distance matrix is computed using
+    `distance_matrix` for each matrix M1 and M2. The entries
+    of this matrix are the distance in L1 metric to the
+    closest 0 pixel in the initial matrix. The distance being
+    0 if it belongs to the basin with id 0.
+"""
+function haussdorff_distance(M1::BitMatrix, M2::BitMatrix)
+    bd1 = distance_matrix(M1)
+    bd2 = distance_matrix(M2)
+    hd1 = maximum(bd1.*M2)
+    hd2 = maximum(bd2.*M1)
+    return max(hd1,hd2)
+end
+
+# wada_fractions computes the distance between
+# boundaries using the hausdorff distance.
+# The distance is computed using the Shonwilker
+# algorithm. The result is a matrix with the distance
+# of the pixels from one boundary to the other.
+# The algorithm returns the number of pixels
+# that are at a distance strictly more than r
+# (with the hausdorff distance).
+function wada_fractions(bas1::BitMatrix, bas2::BitMatrix, r::Int)
+    bnd1 = get_boundary(bas1)
+    bd1 = distance_matrix(bnd1)
+
+    bnd2 = get_boundary(bas2)
+    bd2 = distance_matrix(bnd2)
+
+    c1 = count(bd1.*bnd2 .> r)
+    c2 = count(bd2.*bnd1 .> r)
+    # @show c1, c2
+    return max(c1,c2)./length(bnd1)
+end
+
+
+
+# Return a matrix with two basins: the first is the basins
+# from the attractor in `id`  and the other basin is formed
+# with the union of all others basins.
+# The function returns a BitMatrix such that the basins of
+# `id` is mapped to 0 and the other basins to 1.
+function merged_basins(basins, id)
+    mrg_basins = fill!(BitMatrix(undef,size(basins)), false)
+    ids = setdiff(unique(basins), id)
+    for k in ids
+        I = findall(basins .== k)
+        mrg_basins[I] .= 1
+    end
+    return mrg_basins
+end
+
+
+
+# Generate all pairs of the number in ids without
+# repetition
+function generate_pairs(ids)
+ p = Vector{Tuple{Int,Int}}()
+ for (k,n1) in enumerate(ids)
+     for (j,n2) in enumerate(ids[k+1:end])
+        push!(p,(n1,n2))
+     end
+ end
+ return p
+end
+
+
+# This function returns the boundary between two basins:
+# First we compute the distance matrix of the basins and its
+# complementary. The pixels at distance 1 from a basin are
+# the closest to the boundary. We compute the union the
+# pixels computed from one basins and its complementary.
+# We get the boundary in L1 distance!
+function get_boundary(basins::BitMatrix)
+    bd1 = distance_matrix(basins)
+    bdd1 = distance_matrix( .! basins)
+    bnd = (bd1 .== 1) .| (bdd1 .== 1)
+    return bnd
+end
+
+
+# Function for L1 metric
+w(M) = min(M[1,2]+1, M[2,1]+1, M[2,2])
+w2(M) = min(M[1,2]+1, M[2,1]+1, M[1,1])
+
+# R. Shonkwilker, An image algorithm for computing the Hausdorff distance efficiently in linear time.
+# https://doi.org/10.1016/0020-0190(89)90114-2
+# This compute the Distance transform matrix.
+# Given a matrix, we compute the distance from the
+# basin with label 0. The result is a matrix whose
+# entry is the distance to the closest 0 pixel in the
+# L1 metric (Manhattan).
+function distance_matrix(basins::BitMatrix)
+   r,c = size(basins)
+   basdist = ones(Int32,r+2,c+2)*(r+c+4)
+   # Assign the maximum distance to the pixels not in the basin
+   basdist[2:r+1,2:c+1] .= (1 .- basins) .*(r+c+4)
+   # first pass right to left, up to bottom
+   for j in 2:c+1, k in 2:r+1
+       basdist[j,k] = w(view(basdist,j-1:j,k-1:k))
+    end
+   # second pass left to right, bottom up
+   for j in c+1:-1:1, k in r+1:-1:1
+       basdist[j,k] = w2(view(basdist,j:j+1,k:k+1))
+   end
+   # Remove the extra rows and cols necessary to the alg.
+   return basdist[2:r+1,2:c+1]
+end

--- a/src/basins/wada_test.jl
+++ b/src/basins/wada_test.jl
@@ -121,8 +121,8 @@ end
 """
     test_wada_merge(basins, r) -> p
 
-This function test if the 2D array `basins` has the Wada 
-property using the merging technique [Daza2018](@cite). 
+Test if the 2D array `basins` has the Wada 
+property using the merging technique of [Daza2018](@cite). 
 
 ## Description 
 

--- a/src/basins/wada_test.jl
+++ b/src/basins/wada_test.jl
@@ -61,7 +61,7 @@ end
 
 
 """
-    function haussdorff_distance(M1, M2) -> hd
+    haussdorff_distance(M1, M2) -> hd
 
     Compute the Hausdorff distance between two binary matrices of
     the same size. First a distance matrix is computed using 

--- a/src/basins/wada_test.jl
+++ b/src/basins/wada_test.jl
@@ -37,7 +37,7 @@ function test_wada_merge(basins,r)
     for k in ids
        M[k] = merged_basins(basins,k)
     end
-    v = []
+    v = Vector{Float64}()
     for k in 1:length(M)-1, j in k+1:length(M)
         push!(v,wada_fractions(M[k],M[j],r))
     end
@@ -47,12 +47,12 @@ end
 """
     haussdorff_distance(M1, M2) -> hd
 
-    Compute the Hausdorff distance between two binary matrices of
-    the same size. First a distance matrix is computed using
-    `distance_matrix` for each matrix M1 and M2. The entries
-    of this matrix are the distance in L1 metric to the
-    closest 0 pixel in the initial matrix. The distance being
-    0 if it belongs to the basin with id 0.
+Compute the Hausdorff distance between two binary matrices of
+the same size. First a distance matrix is computed using
+`distance_matrix` for each matrix M1 and M2. The entries
+of this matrix are the distance in L1 metric to the
+closest 0 pixel in the initial matrix. The distance being
+0 if it belongs to the basin with id 0.
 """
 function haussdorff_distance(M1::BitMatrix, M2::BitMatrix)
     bd1 = distance_matrix(M1)
@@ -79,7 +79,6 @@ function wada_fractions(bas1::BitMatrix, bas2::BitMatrix, r::Int)
 
     c1 = count(bd1.*bnd2 .> r)
     c2 = count(bd2.*bnd1 .> r)
-    # @show c1, c2
     return max(c1,c2)./length(bnd1)
 end
 

--- a/src/basins/wada_test.jl
+++ b/src/basins/wada_test.jl
@@ -1,0 +1,156 @@
+export test_wada_merge
+
+# Generate all pairs of the number in ids without 
+# repetition
+function generate_pairs(ids) 
+ p = Vector{Tuple{Int}}()
+ for (k,n1) in enumerate(ids)
+     for (j,n2) in enumerate(ids[k+1:end])
+        push!(p,(n1,n2))
+     end
+ end
+ return p 
+end
+
+
+# This function returns the boundary between two basins: 
+# First we compute the distance matrix of the basins and its 
+# complementary. The pixels at distance 1 from a basin are 
+# the closest to the boundary. We compute the union the 
+# pixels computed from one basins and its complementary. 
+# We get the boundary in L1 distance!
+function get_boundary(basins::BitMatrix) 
+    bd1 = distance_matrix(basins) 
+    bdd1 = distance_matrix( .! basins) 
+    bnd = (bd1 .== 1) .| (bdd1 .== 1)
+    return bnd
+end
+
+
+# Function for L1 metric 
+w(M) = min(M[1,2]+1, M[2,1]+1, M[2,2]) 
+w2(M) = min(M[1,2]+1, M[2,1]+1, M[1,1]) 
+
+# Function for L∞ metric (Chebyshev)
+# w(M) = min(M[1,2]+1, M[2,1]+1, M[2,2], M[1,1] +1) 
+# w2(M) = min(M[1,2]+1, M[2,1]+1, M[1,1], M[2,2] +1) 
+
+# R. Shonkwilker, An image algorithm for computing the Hausdorff distance efficiently in linear time. 
+# https://doi.org/10.1016/0020-0190(89)90114-2
+# This compute the Distance transform matrix.
+# Given a matrix, we compute the distance from the 
+# basin with label 0. The result is a matrix whose 
+# entry is the distance to the closest 0 pixel in the 
+# L1 metric (Manhattan). 
+function distance_matrix(basins::BitMatrix) 
+   r,c = size(basins)
+   basdist = ones(Int32,r+2,c+2)*(r+c+4) 
+   # Assign the maximum distance to the pixels not in the basin
+   basdist[2:r+1,2:c+1] .= (1 .- basins) .*(r+c+4) 
+   # first pass right to left, up to bottom
+   for j in 2:c+1, k in 2:r+1
+       basdist[j,k] = w(view(basdist,j-1:j,k-1:k))
+    end       
+   # second pass left to right, bottom up
+   for j in c+1:-1:1, k in r+1:-1:1
+       basdist[j,k] = w2(view(basdist,j:j+1,k:k+1))
+   end       
+   # Remove the extra rows and cols necessary to the alg. 
+   return basdist[2:r+1,2:c+1]
+end
+
+
+"""
+    function haussdorff_distance(M1, M2) -> hd
+
+    Compute the Hausdorff distance between two binary matrices of
+    the same size. First a distance matrix is computed using 
+    `distance_matrix` for each matrix M1 and M2. The entries
+    of this matrix are the distance in L1 metric to the 
+    closest 0 pixel in the initial matrix. The distance being 
+    0 if it belongs to the basin with id 0. 
+"""
+function haussdorff_distance(M1::BitMatrix, M2::BitMatrix)
+    bd1 = distance_matrix(M1) 
+    bd2 = distance_matrix(M2) 
+    hd1 = maximum(bd1.*M2)
+    hd2 = maximum(bd2.*M1)
+    return max(hd1,hd2)
+end
+
+# wada_fractions computes the distance between 
+# boundaries using the hausdorff distance. 
+# The distance is computed using the Shonwilker 
+# algorithm. The result is a matrix with the distance 
+# of the pixels from one boundary to the other. 
+# The algorithm returns the number of pixels
+# that are at a distance strictly more than r
+# (with the hausdorff distance). 
+function wada_fractions(bas1::BitMatrix, bas2::BitMatrix, r::Int)
+    bnd1 = get_boundary(bas1)
+    bd1 = distance_matrix(bnd1) 
+
+    bnd2 = get_boundary(bas2)
+    bd2 = distance_matrix(bnd2) 
+
+    c1 = count(bd1.*bnd2 .> r)
+    c2 = count(bd2.*bnd1 .> r)
+    # @show c1, c2
+    return max(c1,c2)./length(bnd1)
+end
+
+"""
+   merged_boundary(basins, id) -> basins
+
+Returns a matrix with two basins: the first is the basins 
+from the attractor in `id`  and the other basin is formed 
+with the union of all others basins. 
+The function returns a BitMatrix such that the basins of 
+`id` is mapped to 0 and the other basins to 1.  
+""" 
+function merged_basins(basins, id) 
+    mrg_basins = fill!(BitMatrix(undef,size(basins)), false)
+    ids = setdiff(unique(basins), id)
+    for k in ids 
+        I = findall(basins .== k)
+        mrg_basins[I] .= 1
+    end
+    return mrg_basins
+end
+
+"""
+    test_wada_merge(basins, r) -> p
+
+This function test if the matrix `basins` has the Wada property 
+using the merging technique [Daza2018](@cite). The technique consists in computing 
+the generalized basins of each attractor, this is two new basins
+formed by one of the attractor and the union of the basins of all 
+other attractors. The algorithm then computes the distance between 
+each pair of boundaries of these basins. If all the boundaries are 
+within some distance `r`, then we have the wada property. 
+The algorithm returns the proportion of pixels with distance 
+strictly greater than `r`. If `p == 0`  we have the Wada 
+property for this resolution. If `p > 0`, the criteria to decide if
+the basins are Wada is left to the researcher. 
+Numerical inaccuracies may be responsible for a small percentage
+of points with distance larger than `r`
+
+A. Daza, Alexandre Wagemakers and Miguel A.F. Sanjuán.Ascertaining when a basin is Wada: The merging method. Scientific Reports 8, 9954, 2018.
+"""
+function test_wada_merge(basins,r) 
+    ids = unique(basins)
+    if length(ids) < 3
+        @error "There must be at least 3 attractors"
+        return  Inf
+    end
+    M = Vector{BitMatrix}(undef,length(ids))
+    for k in ids
+       M[k] = merged_basins(basins,k)
+    end
+    v = []
+    for k in 1:length(M)-1, j in k+1:length(M)
+        push!(v,wada_fractions(M[k],M[j],r))
+    end
+    return maximum(v)
+end
+

--- a/src/basins/wada_test.jl
+++ b/src/basins/wada_test.jl
@@ -126,10 +126,10 @@ property using the merging technique [Daza2018](@cite).
 
 ## Description 
 
-The technique consists in computing 
-the generalized basins of each attractor, consisting is two new basins
-formed by one of the basins and the union of the other basins. 
-The algorithm then computes the distance between 
+The technique consists in computing the generalized basins 
+of each attractor. These new basins are formed with on of the basins 
+and the union of the other basins. A new boundary is defined by 
+these two objects. The algorithm then computes the distance between 
 each boundaries of these basins pairwise. If all the boundaries are 
 within some distance `r`, there is a unique boundary separating 
 the basins and we have the wada property. 

--- a/src/basins/wada_test.jl
+++ b/src/basins/wada_test.jl
@@ -1,4 +1,4 @@
-export test_wada_merge
+export test_wada_merge, haussdorff_distance
 
 # Generate all pairs of the number in ids without 
 # repetition
@@ -121,21 +121,26 @@ end
 """
     test_wada_merge(basins, r) -> p
 
-This function test if the matrix `basins` has the Wada property 
-using the merging technique [Daza2018](@cite). The technique consists in computing 
-the generalized basins of each attractor, this is two new basins
-formed by one of the attractor and the union of the basins of all 
-other attractors. The algorithm then computes the distance between 
-each pair of boundaries of these basins. If all the boundaries are 
-within some distance `r`, then we have the wada property. 
-The algorithm returns the proportion of pixels with distance 
-strictly greater than `r`. If `p == 0`  we have the Wada 
-property for this resolution. If `p > 0`, the criteria to decide if
-the basins are Wada is left to the researcher. 
-Numerical inaccuracies may be responsible for a small percentage
-of points with distance larger than `r`
+This function test if the 2D array `basins` has the Wada 
+property using the merging technique [Daza2018](@cite). 
 
-A. Daza, Alexandre Wagemakers and Miguel A.F. Sanjuán.Ascertaining when a basin is Wada: The merging method. Scientific Reports 8, 9954, 2018.
+## Description 
+
+The technique consists in computing 
+the generalized basins of each attractor, consisting is two new basins
+formed by one of the basins and the union of the other basins. 
+The algorithm then computes the distance between 
+each boundaries of these basins pairwise. If all the boundaries are 
+within some distance `r`, there is a unique boundary separating 
+the basins and we have the wada property. 
+The algorithm returns the maximum proportion of pixels of a boundary 
+with distance strictly greater than `r` from another boundary. 
+
+If `p == 0`,  we have the Wada property for this value of `r`. 
+If `p > 0`, the criteria to decide if
+the basins are Wada is left to the researcher. Numerical inaccuracies 
+may be responsible for a small percentage of points with distance larger than `r`
+
 """
 function test_wada_merge(basins,r) 
     ids = unique(basins)

--- a/src/basins/wada_test.jl
+++ b/src/basins/wada_test.jl
@@ -138,7 +138,7 @@ with distance strictly greater than `r` from another boundary.
 
 If `p == 0`,  we have the Wada property for this value of `r`. 
 If `p > 0`, the criteria to decide if
-the basins are Wada is left to the researcher. Numerical inaccuracies 
+the basins are Wada is left to the user. Numerical inaccuracies 
 may be responsible for a small percentage of points with distance larger than `r`
 
 """

--- a/test/basins/wada_tests.jl
+++ b/test/basins/wada_tests.jl
@@ -1,0 +1,13 @@
+using Test
+@testset "Wada property test" begin
+    # Artificial smooth boundary 
+    M = [1 1 1 1 2 2 2 2  3 3 3 3]'*ones(Int, 1,12)
+    @test test_wada_merge(M, 1) == 12*2/12^2
+    @test test_wada_merge(M, 2) == 12*2/12^2
+
+    # Artificial fractal boundary
+    M = [1 2 3 1 2 3 1 2  3 1 2 3]'*ones(Int, 1,12)
+    @test test_wada_merge(M, 1) == 0.
+end
+
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,6 +23,7 @@ testfile(file, testname=defaultname(file)) = @testset "$testname" begin; include
     @testset "basins analysis" begin
         testfile("basins/tipping_points_tests.jl")
         testfile("basins/uncertainty_tests.jl")
+        testfile("basins/wada_tests.jl")
     end
 
     @testset "continuation" begin


### PR DESCRIPTION
This is an implementation of the merging algorithm to detect Wada basins. EDIT: only possible in 2D

It is fast and simple to understand. The distance between boundaries is computed using the distance transform of a binary matrix. See this thread: 

https://cs.stackexchange.com/questions/117989/hausdorff-distance-between-two-binary-images-according-to-distance-maps

The boundaries can also be computed using this distance matrix so the code is minimal and quite fast (a few ms for 1000x1000 basins matrix) 

A. Daza, Alexandre Wagemakers and Miguel A.F. Sanjuán. Ascertaining when a basin is Wada: The merging method. Scientific Reports 8, 9954, 2018.

The basic idea of the algorithm is to compute all boundaries between a basin and the other merged basins. If all boundaries are within some distance r in pixels then we judge that the basins are Wada: there is a unique boundary. 


The Doc still needs improvement and the `haussdorff_distance`  is optional. Tests are based on an artificial basins matrix. 
