### PR TITLE
(2.0) Parameter-by-parameter continuation using featurizing 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.18
+- New continuation mode `FeaturizingFindAndMatch` to be used in `continuation` similarly to how recurrences continuation works, but using `AttractorsViaFeaturizing`.
+- Update `basins_fractions` for `AttractorsViaFeaturizing` to deal with additional ics used for seeding in `continuation`.
+
 # v1.17
 
 - New function `convergence_and_basins_fractions`

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Attractors"
 uuid = "f3fd9213-ca85-4dba-9dfd-7fc91308fec7"
 authors = ["George Datseris <datseris.george@gmail.com>", "Kalel Rossi", "Alexandre Wagemakers"]
 repo = "https://github.com/JuliaDynamics/Attractors.jl.git"
-version = "1.17.0"
+version = "1.18.0"
 
 
 [deps]

--- a/src/continuation/basins_fractions_continuation_api.jl
+++ b/src/continuation/basins_fractions_continuation_api.jl
@@ -53,4 +53,5 @@ function continuation end
 include("match_attractor_ids.jl")
 include("continuation_recurrences.jl")
 include("continuation_grouping.jl")
+include("continuation_featurizing_find_and_match.jl")
 include("aggregate_attractor_fractions.jl")

--- a/src/continuation/basins_fractions_continuation_api.jl
+++ b/src/continuation/basins_fractions_continuation_api.jl
@@ -24,8 +24,12 @@ The basin fractions and the attractors (or some representation of them) are cont
 across the parameter range `prange`, for the parameter of the system with index `pidx`
 (any index valid in [`set_parameter!`](@ref) can be used).
 
-`ics` is a 0-argument function generating initial conditions for
-the dynamical system (as in [`basins_fractions`](@ref)).
+`ics` is 
+- generally a 0-argument function generating initial conditions for
+the dynamical system (as in [`basins_fractions`](@ref)) or
+- in the case of `FeaturizingFindAndMatch`(@ref), a dataset containing the pre-generated
+  initial conditions for the dynamical system (as in [`basins_fractions`](@ref)) for
+  `AttractorsViaFeaturizing`(@ref).
 
 Possible subtypes of `AttractorsBasinsContinuation` are:
 

--- a/src/continuation/continuation_featurizing_find_and_match.jl
+++ b/src/continuation/continuation_featurizing_find_and_match.jl
@@ -1,0 +1,96 @@
+export FeaturizingFindAndMatch
+import ProgressMeter
+using Random: MersenneTwister
+
+struct FeaturizingFindAndMatch{A, M, R<:Real, S, E} <: AttractorsBasinsContinuation
+    mapper::A
+    distance::M
+    threshold::R
+    seeds_from_attractor::S
+    info_extraction::E
+end
+
+"""
+Very similar to the recurrences version, only difference being that the seeding from attractors is different. 
+"""
+function FeaturizingFindAndMatch(
+        mapper::AttractorsViaFeaturizing; distance = Centroid(),
+        threshold = Inf, seeds_from_attractor = _default_seeding_process_featurizing,
+        info_extraction = identity
+    )
+    return FeaturizingFindAndMatch(
+        mapper, distance, threshold, seeds_from_attractor, info_extraction
+    )
+end
+
+function _default_seeding_process_featurizing(attractor::AbstractStateSpaceSet, number_seeded_ics=10; rng = MersenneTwister(1))
+    return [rand(rng, vec(attractor)) for _ in 1:number_seeded_ics] #might lead to repeated ics, which is intended for the continuation
+end
+
+"""
+Continuation here is very similar to the one done with recurrences. The difference is only
+in how the ics from previous attractors are seeded to new parameters. In this case, we get ics sampled the previous attractors and pass them to 
+basins_fractions, which extracts features from them and pushes them together with the other features. 
+This could be generalized somehow so that one function could deal with both of the mappers, reducing this code duplication.
+"""
+function continuation(
+        fam::FeaturizingFindAndMatch,
+        prange, pidx, ics;
+        samples_per_parameter = 100, show_progress = true, keep_track_maximum=true,
+    )
+    progress = ProgressMeter.Progress(length(prange);
+        desc="Continuating basins fractions:", enabled=show_progress
+    )
+
+    if ics isa Function
+        error("`ics` needs to be a Dataset.")
+    end
+
+    (; mapper, distance, threshold) = fam
+    reset!(mapper)
+    # first parameter is run in isolation, as it has no prior to seed from
+    set_parameter!(mapper.ds, pidx, prange[1])
+    fs, _ = basins_fractions(mapper, ics; show_progress = false)
+    # At each parmaeter `p`, a dictionary mapping attractor ID to fraction is created.
+    fractions_curves = [fs]
+    # Furthermore some info about the attractors is stored and returned
+    prev_attractors = deepcopy(extract_attractors(mapper))
+    get_info = attractors -> Dict(
+        k => fam.info_extraction(att) for (k, att) in attractors
+    )
+    info = get_info(prev_attractors)
+    attractors_info = [info]
+    ProgressMeter.next!(progress; showvalues = [("previous parameter", prange[1]),])
+    alltime_maximum_key = maximum(keys(fs))
+    # Continue loop over all remaining parameters
+    for p in prange[2:end]
+        set_parameter!(mapper.ds, pidx, p)
+        reset!(mapper)
+        
+        # Collect ics from previous attractors to pass as additional ics to basins fractions (seeding)
+        # to ensure that the clustering will identify them as clusters, we need to guarantee that there
+        # are at least `min_neighbors` entries
+        num_additional_ics = typeof(mapper.group_config) <: GroupViaClustering ? 5*mapper.group_config.min_neighbors : 5
+        additional_ics = Dataset(vcat(map(att-> 
+            fam.seeds_from_attractor(att, num_additional_ics),
+            values(prev_attractors))...)) #dataset with ics seeded from previous attractors
+        
+        # Now perform basin fractions estimation as normal, utilizing found attractors
+        fs, _ = basins_fractions(mapper, ics;
+            show_progress = false, additional_ics
+        )
+        
+        current_attractors = extract_attractors(mapper)
+        push!(fractions_curves, fs)
+        push!(attractors_info, get_info(current_attractors))
+        overwrite_dict!(prev_attractors, current_attractors)
+        ProgressMeter.next!(progress; showvalues = [("previous parameter", p),])
+    end
+    # Match attractors (and basins)
+    match_continuation!(fractions_curves, attractors_info; distance, threshold)
+    return fractions_curves, attractors_info
+end
+
+function reset!(mapper::AttractorsViaFeaturizing)
+    empty!(mapper.attractors)
+end

--- a/src/mapping/grouping/attractor_mapping_featurizing.jl
+++ b/src/mapping/grouping/attractor_mapping_featurizing.jl
@@ -98,7 +98,7 @@ ValidICS = Union{AbstractStateSpaceSet, Function}
 function basins_fractions(mapper::AttractorsViaFeaturizing, og_ics::ValidICS;
     show_progress = true, N = 1000, additional_ics::Union{ValidICS, Nothing} = nothing,
 )
-    if typeof(additional_ics) <: ValidICS
+    if typeof(additional_ics) <: StateSpaceSet
         all_ics = deepcopy(og_ics)
         append!(all_ics, additional_ics)
         ics = all_ics

--- a/test/continuation/featurizing_fam_continuation.jl
+++ b/test/continuation/featurizing_fam_continuation.jl
@@ -1,0 +1,63 @@
+# This file also tests `aggregate_attractor_fractions`!
+using Test, Attractors
+using Random
+
+@testset "analytic bistable map" begin
+    # This is a fake bistable map that has two equilibrium points
+    # for r > 0.5. It has predictable fractions.
+    function dumb_map(dz, z, p, n)
+        x,y = z
+        r = p[1]
+
+        if r < 0.5
+            dz[1] = dz[2] = 0.0
+        else
+            if x > 0
+                dz[1] = r
+                dz[2] = r
+            else
+                dz[1] = -r
+                dz[2] = -r
+            end
+        end
+        return
+    end
+
+    r = 1.0
+    ds = DeterministicIteratedMap(dumb_map, [0., 0.], [r])
+    featurizer(A,t) = A[end]
+    grouping_config = GroupViaPairwiseComparison(; threshold=0.2)
+    mapper = AttractorsViaFeaturizing(ds, featurizer, grouping_config)
+
+    yg = xg = range(-10., 10, length = 100)
+    grid = (xg,yg)
+    sampler, = statespace_sampler(grid, 1234)
+    samples_per_parameter = 1000
+    ics = Dataset([deepcopy(sampler()) for _ in 1:samples_per_parameter])
+
+    rrange = range(0, 2; length = 20)
+    ridx = 1
+    fsc = FeaturizingFindAndMatch(mapper; threshold = 0.3)
+    fractions_curves, a = continuation(
+        fsc, rrange, ridx, ics;
+        show_progress = false
+    )
+
+    for (i, r) in enumerate(rrange)
+
+        fs = fractions_curves[i]
+        if r < 0.5
+            k = sort!(collect(keys(fs)))
+            @test length(k) == 1
+        else
+            k = sort!(collect(keys(fs)))
+            @test length(k) == 2
+            v = values(fs)
+            for f in v
+                @test (0.4 < f < 0.6)
+            end
+        end
+        @test sum(values(fs)) ≈ 1
+    end
+
+end


### PR DESCRIPTION
Hey, this is a new PR, following up on #69. Sorry I took so long, made all of this a bit unnecessarily complicated.  I came back to this now as I need this continuation for two projects I'm working on. On the previous PR, we were discussing whether it was better to match the attractors found for different parameters using the clouds of features or the attractors themselves. There were good points for using the features, one of them being that there would be no need for reconstructing the attractors. This is true for matching, but, importantly, not for seeding. We need the attractors to sample ics from them to use them as seeds for the attractor-finding algorithm in the subsequent parameter. Thus, since we need the attractors anyway for seeding (which is the heart of the continuation!), then we might as well use them for matching! If the user then wants to match via features, they can just extract the features in their matching function.

In summary, this PR thus implements continuation for AttractorsViaFeaturizing very similarly to how it is implemented for AttractorsViaRecurrences. The only big difference is that the `ics` sent to `continuation` must be pre-generated and stored in a StateSpaceSet, contrary to the sampler function that the AttractorsViaRecurrences version needs. This is because `basins_fractions` requires the `ics` in this way to be able to extract the attractors after grouping the features. Again, the attractors are needed for seeding, so this is necessary.
After attractors are found, initial conditions are sampled from them and sent together with the pre-generated `ics` for `basins_fractions` on the next parameter. The ics are all put together for extracting features and grouping them. 

Let me know what you think! 

I compared this algorithm with the recurrences one for the magnetic pendulum example in the documentations. Here is a comparison
![image](https://github.com/JuliaDynamics/Attractors.jl/assets/38593444/d8746540-87e1-432d-bd4a-746e05997e44)
with the recurrences on the left and the featurizing on the right for 1000 ics per parameter. I think the curves for featurizing are smoother because the `pre-generated` ics are fixed. For recurrences, new `ics` are generated for all parameters, which probably causes the bigger fluctuations. 