### PR TITLE
Add the mapper function for AttractorsViaFeaturinzing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Attractors"
 uuid = "f3fd9213-ca85-4dba-9dfd-7fc91308fec7"
 authors = ["George Datseris <datseris.george@gmail.com>", "Kalel Rossi", "Alexandre Wagemakers"]
 repo = "https://github.com/JuliaDynamics/Attractors.jl.git"
-version = "1.18.5"
+version = "1.18.6"
 
 
 [deps]

--- a/src/mapping/grouping/attractor_mapping_featurizing.jl
+++ b/src/mapping/grouping/attractor_mapping_featurizing.jl
@@ -166,6 +166,12 @@ function extract_features_single(mapper, ics; show_progress = true, N = 1000)
     return feature_vector
 end
 
+# Mapper function that works with GroupViaNearestFeature
+function (mapper::AttractorsViaFeaturizing)(u0)
+   f = extract_features_single(mapper,[u0]) 
+   return feature_to_group(f[1],mapper.group_config) 
+end
+
 # TODO: We need an alternative to deep copying integrators that efficiently
 # initializes integrators for any given kind of system. But that can be done
 # later in the DynamicalSystems.jl 3.0 rework.

--- a/src/mapping/grouping/attractor_mapping_featurizing.jl
+++ b/src/mapping/grouping/attractor_mapping_featurizing.jl
@@ -166,10 +166,9 @@ function extract_features_single(mapper, ics; show_progress = true, N = 1000)
     return feature_vector
 end
 
-# Mapper function that works with GroupViaNearestFeature
 function (mapper::AttractorsViaFeaturizing)(u0)
-   f = extract_features_single(mapper,[u0]) 
-   return feature_to_group(f[1],mapper.group_config) 
+   f = extract_features_single(mapper, [u0]) 
+   return feature_to_group(f[1], mapper.group_config) 
 end
 
 # TODO: We need an alternative to deep copying integrators that efficiently

--- a/test/mapping/attractor_mapping.jl
+++ b/test/mapping/attractor_mapping.jl
@@ -115,6 +115,8 @@ function test_basins(ds, u0s, grid, expected_fs_raw, featurizer;
 
         config = GroupViaNearestFeature(templates; max_distance)
         mapper = AttractorsViaFeaturizing(ds, featurizer, config; Ttr=500)
+        # test the functionality mapper(u0) -> label
+        @test isinteger(mapper(get_state(ds))) == true
         test_basins_fractions(mapper; err = ferr, single_u_mapping = false)
     end
 


### PR DESCRIPTION
Problem described in #137. I added a simple function. It works fine with `GroupViaNearestFeature`, however I don't know what is the behavior for other `GroupConfig.` I suppose it will throw an error since `feature_to_group` is not defined for some GroupConfig.  