### PR TITLE
Improve docstring and performance of `basin_entropy`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Attractors"
 uuid = "f3fd9213-ca85-4dba-9dfd-7fc91308fec7"
 authors = ["George Datseris <datseris.george@gmail.com>", "Kalel Rossi", "Alexandre Wagemakers"]
 repo = "https://github.com/JuliaDynamics/Attractors.jl.git"
-version = "1.19.0"
+version = "1.19.1"
 
 [deps]
 BlackBoxOptim = "a134a8b2-14d6-55f6-9291-3336d3ab0209"

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -2,7 +2,7 @@
 
 Note that the examples utilize some convenience plotting functions offered by Attractors.jl which come into scope when using `Makie` (or any of its backends such as `CairoMakie`), see the [visualization utilities](@ref) for more.
 
-## Newton's fractal (basins of 2D map)
+## Newton's fractal (basins of a 2D map)
 
 ```@example MAIN
 using Attractors

--- a/src/basins/fractality_of_basins.jl
+++ b/src/basins/fractality_of_basins.jl
@@ -42,7 +42,7 @@ function basin_entropy(basins::AbstractArray{Int, D}, ε::Int = 20) where {D}
     return basin_entropy(basins, es)
 end
 
-function basin_entropy(basins::AbstractArray{Int, D}, es::Dims{D})
+function basin_entropy(basins::AbstractArray{Int, D}, es::Dims{D}) where {D}
     Sb = 0.0; Nb = 0
     εranges = map((d, ε) -> 1:ε:d, size(basins), es)
     box_iterator = Iterators.product(εranges...)

--- a/src/basins/fractality_of_basins.jl
+++ b/src/basins/fractality_of_basins.jl
@@ -9,7 +9,9 @@ of the given `basins` of attraction by considering `ε`-sized boxes along each d
 ## Description
 
 First, the n-dimensional input `basins`
-is divided regularly into n-dimensional boxes of side `ε` (same along all dimensions).
+is divided regularly into n-dimensional boxes of side `ε`.
+If `ε` is an integer, the same size is used for all dimensions, otherwise `ε` can be
+a tuple with the same size as the dimensions of `basins`.
 Assuming that there are ``N`` `ε`-boxes that cover the `basins`, the basin entropy is estimated
 as [Daza2016](@cite)
 
@@ -35,12 +37,17 @@ have a fractal boundary, for a more precise test see [`basins_fractal_test`](@re
 An important feature of the basin entropy is that it allows
 comparisons between different basins using the same box size `ε`.
 """
-function basin_entropy(basins::Array, ε = 20)
+function basin_entropy(basins::AbstractArray{Int, D}, ε::Int = 20) where {D}
+    es = ntuple(i -> ε, Val(D))
+    return basin_entropy(basins, es)
+end
+
+function basin_entropy(basins::AbstractArray{Int, D}, es::Dims{D})
     Sb = 0.0; Nb = 0
-    εranges = map(d -> 1:ε:d, size(basins))
+    εranges = map((d, ε) -> 1:ε:d, size(basins), es)
     box_iterator = Iterators.product(εranges...)
     for box_start in box_iterator
-        box_ranges = map(d -> d:(d+ε-1), box_start)
+        box_ranges = map((d, ε) -> d:(d+ε-1), box_start, es)
         box_values = view(basins, box_ranges...)
         uvals = unique(box_values)
         Nb = Nb + (length(uvals) > 1)

--- a/src/basins/fractality_of_basins.jl
+++ b/src/basins/fractality_of_basins.jl
@@ -37,29 +37,28 @@ comparisons between different basins using the same box size `ε`.
 """
 function basin_entropy(basins::Array, ε = 20)
     dims = size(basins)
-    vals = unique(basins)
-    Sb = 0; Nb = 0; N = 0
+    Sb = 0.0; Nb = 0
     bx_tuple = ntuple(i -> range(1, dims[i] - rem(dims[i],ε), step = ε), length(dims))
     box_indices = CartesianIndices(bx_tuple)
     for box in box_indices
         # compute the range of indices for the current box
         I = CartesianIndices(ntuple(i -> range(box[i], box[i]+ε-1, step = 1), length(dims)))
         box_values = [basins[k] for k in I]
-        N = N + 1
         Nb = Nb + (length(unique(box_values)) > 1)
         Sb = Sb + _box_entropy(box_values)
     end
-    return Sb/N, Sb/Nb
+    return Sb/length(box_indices), Sb/Nb
 end
 
 function _box_entropy(box_values)
-    h = 0.
-    for (k,v) in enumerate(unique(box_values))
-        p = count( x -> (x == v), box_values)/length(box_values)
+    h = 0.0
+    for v in unique(box_values)
+        p = count(x -> (x == v), box_values)/length(box_values)
         h += p*log(1/p)
     end
     return h
 end
+
 
 
 

--- a/src/basins/fractality_of_basins.jl
+++ b/src/basins/fractality_of_basins.jl
@@ -49,7 +49,7 @@ function basin_entropy(basins::Array, ε = 20)
     return Sb/length(box_iterator), Sb/Nb
 end
 
-function _box_entropy(box_values, unique_vals)
+function _box_entropy(box_values, unique_vals = unique(box_values))
     h = 0.0
     for v in unique_vals
         p = count(x -> (x == v), box_values)/length(box_values)

--- a/src/basins/fractality_of_basins.jl
+++ b/src/basins/fractality_of_basins.jl
@@ -93,15 +93,12 @@ the estimated value of the boundary basin entropy with the sampling method.
 """
 function basins_fractal_test(basins; ε = 20, Ntotal = 1000)
     dims = size(basins)
-    vals = unique(basins)
-    S=Int(length(vals))
-
     # Sanity check.
     if minimum(dims)/ε < 50
         @warn "Maybe the size of the grid is not fine enough."
     end
     if Ntotal < 100
-        error("Ntotal must be larger than 1000 to gather enough statistics.")
+        error("Ntotal must be larger than 100 to gather enough statistics.")
     end
 
     v_pts = zeros(Float64, length(dims), prod(dims))
@@ -111,7 +108,7 @@ function basins_fractal_test(basins; ε = 20, Ntotal = 1000)
     end
     tree = searchstructure(KDTree, v_pts, Euclidean())
     # Now get the values in the boxes.
-    Nb = 1; N = 1; Sb = 0;
+    Nb = 1
     N_stat = zeros(Ntotal)
     while Nb < Ntotal
         p = [rand()*(sz-ε)+ε for sz in dims]

--- a/src/basins/fractality_of_basins.jl
+++ b/src/basins/fractality_of_basins.jl
@@ -50,8 +50,12 @@ function basin_entropy(basins::AbstractArray{Int, D}, es::Dims{D}) where {D}
         box_ranges = map((d, ε) -> d:(d+ε-1), box_start, es)
         box_values = view(basins, box_ranges...)
         uvals = unique(box_values)
-        Nb = Nb + (length(uvals) > 1)
-        Sb = Sb + _box_entropy(box_values, uvals)
+        if length(uvals) > 1
+            Nb += 1
+            # we only need to estimate entropy for boxes with more than 1 val,
+            # because in other cases the entropy is zero
+            Sb = Sb + _box_entropy(box_values, uvals)
+        end
     end
     return Sb/length(box_iterator), Sb/Nb
 end

--- a/src/basins/fractality_of_basins.jl
+++ b/src/basins/fractality_of_basins.jl
@@ -60,7 +60,7 @@ function _box_entropy(box_values, unique_vals = unique(box_values))
     h = 0.0
     for v in unique_vals
         p = count(x -> (x == v), box_values)/length(box_values)
-        h += p*log(1/p)
+        h += -p*log(p)
     end
     return h
 end

--- a/src/basins/fractality_of_basins.jl
+++ b/src/basins/fractality_of_basins.jl
@@ -37,7 +37,7 @@ comparisons between different basins using the same box size `ε`.
 """
 function basin_entropy(basins::Array, ε = 20)
     Sb = 0.0; Nb = 0
-    εranges = map(d -> 1:ε:(d - rem(d, ε)), size(basins))
+    εranges = map(d -> 1:ε:d, size(basins))
     box_iterator = Iterators.product(εranges...)
     for box_start in box_iterator
         box_ranges = map(d -> d:(d+ε-1), box_start)

--- a/src/basins/fractality_of_basins.jl
+++ b/src/basins/fractality_of_basins.jl
@@ -3,20 +3,30 @@ export uncertainty_exponent, basins_fractal_dimension, basins_fractal_test, basi
 """
     basin_entropy(basins::Array, ε = 20) -> Sb, Sbb
 
-Compute the basin entropy [Daza2016](@cite) `Sb` and basin boundary entropy `Sbb`
-of the given `basins` of attraction by considering `ε` boxes along each dimension.
+Return the basin entropy [Daza2016](@cite) `Sb` and basin boundary entropy `Sbb`
+of the given `basins` of attraction by considering `ε`-sized boxes along each dimension.
 
 ## Description
 
-First, the input `basins`
-is divided regularly into n-dimensional boxes of side `ε` (along all dimensions).
-Then `Sb` is simply the average of the Gibbs entropy computed over these boxes. The
-function returns the basin entropy `Sb` as well as the boundary basin entropy `Sbb`.
-The later is the average of the entropy only for boxes that contains at least two
+First, the n-dimensional input `basins`
+is divided regularly into n-dimensional boxes of side `ε` (same along all dimensions).
+Assuming that there are ``N`` `ε`-boxes that cover the `basins`, the basin entropy is estimated
+as [Daza2016](@cite)
+
+```math
+S_b = \\tfrac{1}{N}\\sum_{i=1}^{N}\\sum_{j=1}^{m_i}-p_{ij}\\log(p_{ij})
+```
+where ``m`` is the number of unique IDs (integers of `basins`) in box ``i``
+and ``p_{ij}`` is the relative frequency (probability) to obtain ID ``j``
+in the ``i`` box (simply the count of IDs ``j`` divided by the total in the box).
+
+`Sbb` is the boundary basin entropy `Sbb`.
+This follows the same definition as ``S_b``, but now averaged over only
+only boxes that contains at least two
 different basins, that is, for the boxes on the boundaries.
 
 The basin entropy is a measure of the uncertainty on the initial conditions of the basins.
-It is maximum at the value `log(n_att)` being `n_att` the number of attractors. In
+It is maximum at the value `log(n_att)` being `n_att` the number of unique IDs in `basins`. In
 this case the boundary is intermingled: for a given initial condition we can find
 another initial condition that lead to another basin arbitrarily close. It provides also
 a simple criterion for fractality: if the boundary basin entropy `Sbb` is above `log(2)`
@@ -25,7 +35,7 @@ have a fractal boundary, for a more precise test see [`basins_fractal_test`](@re
 An important feature of the basin entropy is that it allows
 comparisons between different basins using the same box size `ε`.
 """
-function basin_entropy(basins, ε = 20)
+function basin_entropy(basins::Array, ε = 20)
     dims = size(basins)
     vals = unique(basins)
     Sb = 0; Nb = 0; N = 0

--- a/src/basins/fractality_of_basins.jl
+++ b/src/basins/fractality_of_basins.jl
@@ -22,7 +22,7 @@ where ``m`` is the number of unique IDs (integers of `basins`) in box ``i``
 and ``p_{ij}`` is the relative frequency (probability) to obtain ID ``j``
 in the ``i`` box (simply the count of IDs ``j`` divided by the total in the box).
 
-`Sbb` is the boundary basin entropy `Sbb`.
+`Sbb` is the boundary basin entropy.
 This follows the same definition as ``S_b``, but now averaged over only
 only boxes that contains at least two
 different basins, that is, for the boxes on the boundaries.


### PR DESCRIPTION
I was reading it and I couldn't figure out how the probabilities were computed so I added the equation from the paper. I also looked at the source code that could be optimized. In the end the optimizATIONS don't bring much performance 
```
julia> @btime basin_entropy($basins)
  1.700 ms (5200 allocations: 1.68 MiB)
(0.1944289341841219, 0.7070143061240797)

julia> @btime basin_entropy2($basins)
  1.576 ms (2400 allocations: 212.50 KiB)
(0.1944289341841219, 0.7070143061240797)
```
but at least they reduce the allocated memory 16x fold.