### PR TITLE
Fixing BasinEnclosure matcher

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Attractors"
 uuid = "f3fd9213-ca85-4dba-9dfd-7fc91308fec7"
 authors = ["George Datseris <datseris.george@gmail.com>", "Kalel Rossi", "Alexandre Wagemakers"]
 repo = "https://github.com/JuliaDynamics/Attractors.jl.git"
-version = "1.19.1"
+version = "1.19.4"
 
 [deps]
 BlackBoxOptim = "a134a8b2-14d6-55f6-9291-3336d3ab0209"

--- a/src/matching/basin_enclosure.jl
+++ b/src/matching/basin_enclosure.jl
@@ -61,8 +61,8 @@ function next_key(dict)
 end
 
 # missing key: a key that is in a₊ but not in keys(rmap);
-# when keys are swapped, this missing key might be lost 
-# to fix it, I add the missing key to rmap, pointing to the next available key 
+# when keys are swapped, this missing key might be lost
+# to fix it, I add the missing key to rmap, pointing to the next available key
 function add_missing_keys_rmap!(rmap, current_attractors)
     allkeys = collect(keys(current_attractors))
     usedkeys = collect(keys(rmap))
@@ -72,7 +72,7 @@ function add_missing_keys_rmap!(rmap, current_attractors)
     end
     return
 end
- 
+
 function matching_map(
         current_attractors, prev_attractors, matcher::MatchByBasinEnclosure;
         ds, p, pprev = nothing, next_id = next_free_id(current_attractors, prev_attractors)

--- a/src/matching/basin_enclosure.jl
+++ b/src/matching/basin_enclosure.jl
@@ -92,6 +92,7 @@ function matching_map(
     for (new_ID, old_flowed_to_same) in grouped_flows
         if length(old_flowed_to_same) == 0 # none of the old IDs converged to the current `new_ID`
             rmap[new_ID] = next_id #necessary to make rmap complete and avoid skipping keys
+            next_id += 1
         elseif length(old_flowed_to_same) == 1
             rmap[new_ID] = only(old_flowed_to_same)
         else # need to resolve coflowing using distances

--- a/src/matching/sssdistance.jl
+++ b/src/matching/sssdistance.jl
@@ -108,9 +108,6 @@ function _matching_map_distances(keys₊, keys₋, distances::Dict, threshold;
         end
     end
 
-    # the final step is to filter out equivalent mappings where key and value are the same
-    # filter!(p -> p.first ≠ p.second, rmap)
-
     return rmap
 end
 

--- a/src/matching/sssdistance.jl
+++ b/src/matching/sssdistance.jl
@@ -109,7 +109,8 @@ function _matching_map_distances(keys₊, keys₋, distances::Dict, threshold;
     end
 
     # the final step is to filter out equivalent mappings where key and value are the same
-    filter!(p -> p.first ≠ p.second, rmap)
+    # filter!(p -> p.first ≠ p.second, rmap)
+
     return rmap
 end
 

--- a/test/continuation/matching_attractors.jl
+++ b/test/continuation/matching_attractors.jl
@@ -167,7 +167,7 @@ end # Matcher by distance tests
 end
 
 @testset "BasinEncloure" begin
-   
+
     @testset "synthetic multistable continuation" begin
         function dummy_multistable_equilibrium!(dx, x, p, n)
             r = p[1]
@@ -182,41 +182,41 @@ end
             att_of_x = findlast(xatt->xatt<=x[1], x_atts)
             if x[1] < 0 att_of_x = 1 end
             dx .= x_atts[att_of_x]
-                
+
             return nothing
         end
-        
+
         ds = DeterministicIteratedMap(dummy_multistable_equilibrium!, [0.], [1.0])
         featurizer(A,t) = A[end]
         grouping_config = GroupViaPairwiseComparison(; threshold=0.2)
         mapper = AttractorsViaFeaturizing(ds, featurizer, grouping_config)
-        
+
         xg = range(0, 10, length = 100)
         grid = (xg,)
         sampler, = statespace_sampler(grid, 1234)
         samples_per_parameter = 1000
         ics = Dataset([deepcopy(sampler()) for _ in 1:samples_per_parameter])
-    
+
         rrange = range(1, 9.5; step=0.5)
         ridx = 1
-    
+
         mapper = AttractorsViaFeaturizing(ds, featurizer, grouping_config; T=10, Ttr=1)
-        matcher  = MatchByBasinEnclosure(;ε=0.1) 
+        matcher  = MatchByBasinEnclosure(;ε=0.1)
         assc = AttractorSeedContinueMatch(mapper, matcher)
         fs_curves, atts_all = global_continuation(assc, rrange, ridx, ics; show_progress = true)
-        
+
         atts_all_endpoint_solution = Dict{Int64, SVector{1, Float64}}[Dict(1 => [0.0]), Dict(1 => [0.0]), Dict(2 => [2.0], 1 => [0.0]), Dict(2 => [2.0], 1 => [0.0]), Dict(2 => [2.0], 3 => [4.0], 1 => [-5.0]), Dict(2 => [2.0], 3 => [4.0], 1 => [-5.0]), Dict(4 => [6.0], 2 => [2.0], 3 => [4.0], 1 => [0.0]), Dict(4 => [6.0], 2 => [2.0], 3 => [4.0], 1 => [0.0]), Dict(5 => [8.0], 4 => [6.0], 2 => [2.0], 3 => [4.0], 1 => [0.0]), Dict(5 => [8.0], 4 => [6.0], 2 => [2.0], 3 => [4.0], 1 => [0.0]), Dict(4 => [6.0], 2 => [2.0], 3 => [4.0], 1 => [0.0]), Dict(4 => [6.0], 2 => [2.0], 3 => [4.0], 1 => [0.0]), Dict(2 => [2.0], 3 => [4.0], 1 => [0.0]), Dict(2 => [2.0], 3 => [4.0], 1 => [0.0]), Dict(2 => [2.0], 1 => [0.0]), Dict(2 => [2.0], 1 => [0.0]), Dict(1 => [0.0]), Dict(1 => [0.0])]
-        atts_all_endpoint = [Dict(k=>v[end] for (k,v) in atts) for atts in atts_all] 
+        atts_all_endpoint = [Dict(k=>v[end] for (k,v) in atts) for atts in atts_all]
 
         @test atts_all_endpoint == atts_all_endpoint_solution
-        
+
         fs_curves_solution = [Dict(1 => 1.0), Dict(1 => 1.0), Dict(2 => 0.8, 1 => 0.2), Dict(2 => 0.8, 1 => 0.2), Dict(2 => 0.2, 3 => 0.6, 1 => 0.2), Dict(2 => 0.2, 3 => 0.6, 1 => 0.2), Dict(4 => 0.4, 2 => 0.2, 3 => 0.2, 1 => 0.2), Dict(4 => 0.4, 2 => 0.2, 3 => 0.2, 1 => 0.2), Dict(5 => 0.2, 4 => 0.2, 2 => 0.2, 3 => 0.2, 1 => 0.2), Dict(5 => 0.2, 4 => 0.2, 2 => 0.2, 3 => 0.2, 1 => 0.2), Dict(4 => 0.4, 2 => 0.2, 3 => 0.2, 1 => 0.2), Dict(4 => 0.4, 2 => 0.2, 3 => 0.2, 1 => 0.2), Dict(2 => 0.2, 3 => 0.6, 1 => 0.2), Dict(2 => 0.2, 3 => 0.6, 1 => 0.2), Dict(2 => 0.8, 1 => 0.2), Dict(2 => 0.8, 1 => 0.2), Dict(1 => 1.0), Dict(1 => 1.0)]
         @test all(keys.(fs_curves_solution) .== keys.(fs_curves)    )
         for (fs_curve, fs_curve_solution) in zip(fs_curves, fs_curves_solution)
             for (k, fs) in fs_curve
                 @test isapprox(fs, fs_curve_solution[k], atol=1e-1)
-            end 
+            end
         end
     end
-    
+
 end

--- a/test/continuation/matching_attractors.jl
+++ b/test/continuation/matching_attractors.jl
@@ -201,18 +201,20 @@ end
         ridx = 1
     
         mapper = AttractorsViaFeaturizing(ds, featurizer, grouping_config; T=10, Ttr=1)
-        assc = AttractorSeedContinueMatch(mapper, default)
+        matcher  = MatchByBasinEnclosure(;ε=0.1) 
+        assc = AttractorSeedContinueMatch(mapper, matcher)
         fs_curves, atts_all = global_continuation(assc, rrange, ridx, ics; show_progress = true)
-        atts_keys = keys.(atts_all)
         
-        atts_keys_solution = [[1], [1], [2, 1], [2, 1], [2, 3, 1], [2, 3, 1], [4, 2, 3, 1], [4, 2, 3, 1], [5, 4, 2, 3, 1], [5, 4, 2, 3, 1], [4, 2, 3, 1], [4, 2, 3, 1], [2, 3, 1], [2, 3, 1], [2, 3], [2, 3], [3], [3]]
-        fs_curves_solution = [Dict(1 => 1.0), Dict(1 => 1.0), Dict(2 => 0.8, 1 => 0.2), Dict(2 => 0.2, 1 => 0.8), Dict(2 => 0.2, 3 => 0.6, 1 => 0.2), Dict(2 => 0.6, 3 => 0.2, 1 => 0.2), Dict(4 => 0.4, 2 => 0.2, 3 => 0.2, 1 => 0.2), Dict(4 => 0.2, 2 => 0.2, 3 => 0.2, 1 => 0.4), Dict(5 => 0.2, 4 => 0.2, 2 => 0.2, 3 => 0.2, 1 => 0.2)]
+        atts_all_endpoint_solution = Dict{Int64, SVector{1, Float64}}[Dict(1 => [0.0]), Dict(1 => [0.0]), Dict(2 => [2.0], 1 => [0.0]), Dict(2 => [2.0], 1 => [0.0]), Dict(2 => [2.0], 3 => [4.0], 1 => [-5.0]), Dict(2 => [2.0], 3 => [4.0], 1 => [-5.0]), Dict(4 => [6.0], 2 => [2.0], 3 => [4.0], 1 => [0.0]), Dict(4 => [6.0], 2 => [2.0], 3 => [4.0], 1 => [0.0]), Dict(5 => [8.0], 4 => [6.0], 2 => [2.0], 3 => [4.0], 1 => [0.0]), Dict(5 => [8.0], 4 => [6.0], 2 => [2.0], 3 => [4.0], 1 => [0.0]), Dict(4 => [6.0], 2 => [2.0], 3 => [4.0], 1 => [0.0]), Dict(4 => [6.0], 2 => [2.0], 3 => [4.0], 1 => [0.0]), Dict(2 => [2.0], 3 => [4.0], 1 => [0.0]), Dict(2 => [2.0], 3 => [4.0], 1 => [0.0]), Dict(2 => [2.0], 1 => [0.0]), Dict(2 => [2.0], 1 => [0.0]), Dict(1 => [0.0]), Dict(1 => [0.0])]
+        atts_all_endpoint = [Dict(k=>v[end] for (k,v) in atts) for atts in atts_all] 
+
+        @test atts_all_endpoint == atts_all_endpoint_solution
         
-        @test all(Set.(atts_keys) .== Set.(atts_keys_solution))
-        @test all(Set.(atts_keys) .== Set.(keys.(fs_curves)))
+        fs_curves_solution = [Dict(1 => 1.0), Dict(1 => 1.0), Dict(2 => 0.8, 1 => 0.2), Dict(2 => 0.8, 1 => 0.2), Dict(2 => 0.2, 3 => 0.6, 1 => 0.2), Dict(2 => 0.2, 3 => 0.6, 1 => 0.2), Dict(4 => 0.4, 2 => 0.2, 3 => 0.2, 1 => 0.2), Dict(4 => 0.4, 2 => 0.2, 3 => 0.2, 1 => 0.2), Dict(5 => 0.2, 4 => 0.2, 2 => 0.2, 3 => 0.2, 1 => 0.2), Dict(5 => 0.2, 4 => 0.2, 2 => 0.2, 3 => 0.2, 1 => 0.2), Dict(4 => 0.4, 2 => 0.2, 3 => 0.2, 1 => 0.2), Dict(4 => 0.4, 2 => 0.2, 3 => 0.2, 1 => 0.2), Dict(2 => 0.2, 3 => 0.6, 1 => 0.2), Dict(2 => 0.2, 3 => 0.6, 1 => 0.2), Dict(2 => 0.8, 1 => 0.2), Dict(2 => 0.8, 1 => 0.2), Dict(1 => 1.0), Dict(1 => 1.0)]
+        @test all(keys.(fs_curves_solution) .== keys.(fs_curves)    )
         for (fs_curve, fs_curve_solution) in zip(fs_curves, fs_curves_solution)
             for (k, fs) in fs_curve
-                @test isapprox(fs, fs_curve_solution[k], atol=1e-3)
+                @test isapprox(fs, fs_curve_solution[k], atol=1e-1)
             end 
         end
     end


### PR DESCRIPTION
I have updated the code for the BasinEnclosure method with two main fixes:
1. get the logic right for `_grouped_flows_`
2. fix missing entries in rmaps. When dealing with coflowing attractors we modify `rmap`. But this might leading to missing keys. In this case, the simplest solution I found was to add those missing keys back with the next available integer key in `rmap`. 

I've tested this with a synthetic multistable system, whose code I've also added to the continuation test suite. The correct behavior is as shown on the left column. Note that the attractor at 0.0 moves to -5.0, with the initial conditions following it. The algorithm identifies and correctly matches the attractors. Note that the other matcher, which relies on distances in state space, misses this. Because 0 is closer to 4 than to -5, it matches 0 to 4, and considers -5 as a new attractor.

![georgescode_matching_by_flow_example-method-2-dummy_multistable_equilibrium!](https://github.com/user-attachments/assets/ff33e177-916f-4d89-bc0a-bc1721da947b)

I've made some more tests using a similar system, in which the attractors are oscillating. The results are the same.
![georgescode_matching_by_flow_example-method-2-dummy_multistable_sinusoidal!](https://github.com/user-attachments/assets/88f28f0d-f1e4-455b-b8d8-216f45e3955c)

I've also played with some different synthetic scenarios, and the code also worked there. Further, I tested on the example we used for continuation with featurizing in the magnetic pendulum, and the code also worked there.

I will test this on the Kuramoto networks, but not now. It is somewhat involved for the important testcases (with N=100) and I have to work on other projects first.