### PR TITLE
Allow initial conditions to be abstract vectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.21
+
+- Initial conditions given to `basins_fractions` and similar functions have been generalized to `AbstractVector` from `StateSpaceSet`. In practice this means that it is now possible to pass in as initial conditions a vector of dictionaries, which allows specifying initial conditions via a mapping of symbolic variables if the dynamical system was made via ModelingToolkit.jl.
+
 # v1.20
 
 - `AttractorsViaProximity` has been significantly improved: it now allows for a keyword `distance`. This keyword decides how the distance between the trajectory end-point and the attractors is decided. The function has further been simplified and re-uses the existing `set_distance` function. The default `distance` keeps the previous behavior unaltered.

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Attractors"
 uuid = "f3fd9213-ca85-4dba-9dfd-7fc91308fec7"
 authors = ["George Datseris <datseris.george@gmail.com>", "Kalel Rossi", "Alexandre Wagemakers"]
 repo = "https://github.com/JuliaDynamics/Attractors.jl.git"
-version = "1.20.0"
+version = "1.21.0"
 
 [deps]
 BlackBoxOptim = "a134a8b2-14d6-55f6-9291-3336d3ab0209"

--- a/src/basins/basins_utilities.jl
+++ b/src/basins/basins_utilities.jl
@@ -103,7 +103,7 @@ function convergence_and_basins_of_attraction(mapper::AttractorMapper, grid; sho
 end
 
 """
-    convergence_and_basins_fractions(mapper::AttractorMapper, ics::StateSpaceSet)
+    convergence_and_basins_fractions(mapper::AttractorMapper, ics)
 
 An extension of [`basins_fractions`](@ref).
 Return `fs, labels, convergence`. The first two are as in `basins_fractions`,
@@ -117,10 +117,10 @@ See also [`convergence_time`](@ref).
 
 - `show_progress = true`: show progress bar.
 """
-function convergence_and_basins_fractions(mapper::AttractorMapper, ics::AbstractStateSpaceSet;
-        show_progress = true,
+function convergence_and_basins_fractions(mapper::AttractorMapper, ics::ValidICS;
+        show_progress = true, N = 1000,
     )
-    N = size(ics, 1)
+    N = ics isa Function ? N : length(ics)
     progress = ProgressMeter.Progress(N;
         desc="Mapping initial conditions to attractors:", enabled = show_progress
     )

--- a/src/basins/basins_utilities.jl
+++ b/src/basins/basins_utilities.jl
@@ -130,7 +130,7 @@ function convergence_and_basins_fractions(mapper::AttractorMapper, ics::ValidICS
 
     for i ∈ 1:N
         ic = _get_ic(ics, i)
-        label = mapper(ic; show_progress)
+        label = mapper(ic; show_progress = false)
         fs[label] = get(fs, label, 0) + 1
         labels[i] = label
         iterations[i] = convergence_time(mapper)

--- a/src/mapping/attractor_mapping_proximity.jl
+++ b/src/mapping/attractor_mapping_proximity.jl
@@ -53,11 +53,11 @@ function AttractorsViaProximity(ds::DynamicalSystem, attractors::Dict, ε = noth
         Δt=1, Ttr=100, consecutive_lost_steps=1000, horizon_limit=1e3, verbose = false,
         distance = StrictlyMinimumDistance(),
     )
-    if keytype(attractors) <: AbstractStateSpaceSet
-        error("The input attractors must be a dictionary of `StateSpaceSet`s.")
+    if !(valtype(attractors) <: AbstractStateSpaceSet)
+        error("The input attractors must be a dictionary with values of `StateSpaceSet`s.")
     end
     if dimension(ds) ≠ dimension(first(attractors)[2])
-        error("Dimension of the dynamical system and candidate attractors must match")
+        error("Dimension of the dynamical system and candidate attractors must match.")
     end
 
     if distance isa Union{Hausdorff, StrictlyMinimumDistance}

--- a/src/mapping/grouping/attractor_mapping_featurizing.jl
+++ b/src/mapping/grouping/attractor_mapping_featurizing.jl
@@ -102,8 +102,6 @@ function Base.show(io::IO, mapper::AttractorsViaFeaturizing)
     return
 end
 
-ValidICS = Union{AbstractStateSpaceSet, Function}
-
 #####################################################################################
 # Extension of `AttractorMapper` API
 #####################################################################################
@@ -124,7 +122,7 @@ function basins_fractions(mapper::AttractorsViaFeaturizing, ics::ValidICS;
     fs = basins_fractions(group_labels) # Vanilla fractions method with Array input
     # we can always extract attractors because we store all initial conditions
     extract_attractors!(mapper, group_labels, icscol)
-    if typeof(ics) <: AbstractStateSpaceSet
+    if typeof(ics) <: AbstractVector
         return fs, group_labels
     else
         return fs

--- a/test/mapping/basins_of_attraction.jl
+++ b/test/mapping/basins_of_attraction.jl
@@ -48,10 +48,13 @@ end
     set_state!(ds, 0.0, 2)
     ics = [Dict(1 => x) for x in xg]
     fs, labels, iterations = convergence_and_basins_fractions(mapper, ics)
+    fs2, labels = basins_fractions(mapper, ics)
 
-    @test length(fs) == 2
-    @test fs[1] ≈ 0.66 atol = 1e-2
-    @test fs[2] ≈ 0.33 atol = 1e-2
+    for fs in (fs, fs2)
+        @test length(fs) == 2
+        @test fs[1] ≈ 0.66 atol = 1e-2
+        @test fs[2] ≈ 0.33 atol = 1e-2
+    end
 
 end
 

--- a/test/mapping/basins_of_attraction.jl
+++ b/test/mapping/basins_of_attraction.jl
@@ -50,7 +50,8 @@ end
     fs, labels, iterations = convergence_and_basins_fractions(mapper, ics)
 
     @test length(fs) == 2
-    @test 0.4 < fs[1] < 0.6
+    @test fs[1] ≈ 0.66 atol = 1e-2
+    @test fs[2] ≈ 0.33 atol = 1e-2
 
 end
 

--- a/test/mapping/basins_of_attraction.jl
+++ b/test/mapping/basins_of_attraction.jl
@@ -24,18 +24,33 @@ grid = (xg, yg)
 attrs = Dict(1 => StateSpaceSet([SVector(r, r)]), 2 => StateSpaceSet([SVector(-r, -r)]))
 mapper = AttractorsViaProximity(ds, attrs; Ttr = 0)
 
-basins, atts = basins_of_attraction(mapper, grid; show_progress=false)
+@testset "boa" begin
+    basins, atts = basins_of_attraction(mapper, grid; show_progress=false)
 
-@test basins[1, :] == fill(2, 3)
-@test basins[2, :] == fill(1, 3)
-@test basins[3, :] == fill(1, 3)
+    @test basins[1, :] == fill(2, 3)
+    @test basins[2, :] == fill(1, 3)
+    @test basins[3, :] == fill(1, 3)
+end
 
+@testset "boa convergence" begin
 
+    basins, atts, iterations = convergence_and_basins_of_attraction(mapper, grid; show_progress=false)
 
-basins, atts, iterations = convergence_and_basins_of_attraction(mapper, grid; show_progress=false)
+    @test basins[1, :] == fill(2, 3)
+    @test basins[2, :] == fill(1, 3)
+    @test basins[3, :] == fill(1, 3)
+    @test length(atts) == 2
+    @test iterations == fill(1,3,3)
+end
 
-@test basins[1, :] == fill(2, 3)
-@test basins[2, :] == fill(1, 3)
-@test basins[3, :] == fill(1, 3)
-@test length(atts) == 2
-@test iterations == fill(1,3,3)
+@testset "dict set state" begin
+
+    set_state!(ds, 2, 0.0)
+    ics = [Dict(1 => x) for x in xg]
+    fs, labels, iterations = convergence_and_basins_fractions(mapper, ics)
+
+    @test length(fs) == 2
+    @test 0.4 < fs[1] < 0.6
+
+end
+

--- a/test/mapping/basins_of_attraction.jl
+++ b/test/mapping/basins_of_attraction.jl
@@ -45,7 +45,7 @@ end
 
 @testset "dict set state" begin
 
-    set_state!(ds, 2, 0.0)
+    set_state!(ds, 0.0, 2)
     ics = [Dict(1 => x) for x in xg]
     fs, labels, iterations = convergence_and_basins_fractions(mapper, ics)
 


### PR DESCRIPTION
With SSSets.jl v2, they are now `AbstractVector` subtypes. I make the change here because importantly it allows passing as initial conditoins vector of dictionaries. If I make my dynamical system via ModelingToolkit.jl, I don't want to keep track of the order of the dynamic variables. The only way to do this properly is via setting them by name which can only hppen via a dictionary as an initial condition (in contrast to a static vector of real numbers). This PR makes this possible. 