### PR TITLE
Fix link to examples, use ref->id.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Attractors"
 uuid = "f3fd9213-ca85-4dba-9dfd-7fc91308fec7"
 authors = ["George Datseris <datseris.george@gmail.com>", "Kalel Rossi", "Alexandre Wagemakers"]
 repo = "https://github.com/JuliaDynamics/Attractors.jl.git"
-version = "1.24.4"
+version = "1.24.5"
 
 
 [deps]

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -1,4 +1,4 @@
-# [Examples for Attractors.jl](@ref examples)
+# [Examples for Attractors.jl](@id examples)
 
 Note that the examples utilize some convenience plotting functions offered by Attractors.jl which come into scope when using `Makie` (or any of its backends such as `CairoMakie`), see the [visualization utilities](@ref) for more.
 


### PR DESCRIPTION
Without this the generated docs will throw a 404 error when clicking the 'examples' link, say from the index page.