### PR TITLE
critical fix in convergence time of recurrences mapper

### DIFF
--- a/src/mapping/recurrences/attractor_mapping_recurrences.jl
+++ b/src/mapping/recurrences/attractor_mapping_recurrences.jl
@@ -185,7 +185,7 @@ function convergence_time(m::AttractorsViaRecurrences)
     else
         x = get(kw, :consecutive_attractor_steps, 2)
     end
-    x = max(i, x) # it cannot be more than i!
+    x = min(i, x) # it cannot be more than i!
     return (i - x + 1)*m.bsn_nfo.Δt
 end
 


### PR DESCRIPTION
We **desperately** need rigorous tests for the convergence time estimation of `AttractorsViaRecurrences`. The fact that I've "fixed" this function 3 times, yet was still giving totally wrong results is a testament to that. I've been sloppy to not write tests and someone (me or someone else) needs to contribute rigorous tests for this function and this mapper.

cc @andreasmorr this function will now give massively different results, and much more correct ones.
