### PR TITLE
Test for the bug patch in #177

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Attractors"
 uuid = "f3fd9213-ca85-4dba-9dfd-7fc91308fec7"
 authors = ["George Datseris <datseris.george@gmail.com>", "Kalel Rossi", "Alexandre Wagemakers"]
 repo = "https://github.com/JuliaDynamics/Attractors.jl.git"
-version = "1.26.2"
+version = "1.26.3"
 
 
 [deps]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -28,6 +28,13 @@ pages = [
     Documenter.hide("recurrences_animation.md"),
 ]
 
+size_threshold_ignore = [
+    "tutorial.md",
+    "api.md",
+    "examples.md",
+    "references.md",
+]
+
 import Downloads
 Downloads.download(
     "https://raw.githubusercontent.com/JuliaDynamics/doctheme/master/build_docs_with_style.jl",
@@ -44,4 +51,5 @@ bib = CitationBibliography(
 
 build_docs_with_style(pages, Attractors, StateSpaceSets;
     expandfirst = ["index.md"], bib, warnonly = [:doctest, :missing_docs, :cross_references],
+    htmlkw = (;size_threshold_ignore)
 )

--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -295,6 +295,10 @@ series = {KDD'96}
 @article{Morr2025,
   title = {To be published},
   author = {Andreas Morr, George Datseris},
+  journal = {},
+  volume = {},
+  number = {},
+  pages = {},
   year = {2025},
 }
 

--- a/src/mapping/recurrences/attractor_mapping_recurrences.jl
+++ b/src/mapping/recurrences/attractor_mapping_recurrences.jl
@@ -200,7 +200,7 @@ conditions to map to attractors, the method can further utilize found exit and a
 basins, making the computation faster as the grid is processed more and more.
 """
 function basins_of_attraction(mapper::AttractorsViaRecurrences; show_progress = true)
-    basins = mapper.bsn_nfo.basins
+    basins = copy(mapper.bsn_nfo.basins)
     if basins isa SparseArray;
         throw(ArgumentError("""
             Sparse version of AttractorsViaRecurrences is incompatible with

--- a/src/mapping/recurrences/attractor_mapping_recurrences.jl
+++ b/src/mapping/recurrences/attractor_mapping_recurrences.jl
@@ -200,7 +200,7 @@ conditions to map to attractors, the method can further utilize found exit and a
 basins, making the computation faster as the grid is processed more and more.
 """
 function basins_of_attraction(mapper::AttractorsViaRecurrences; show_progress = true)
-    basins = copy(mapper.bsn_nfo.basins)
+    basins = mapper.bsn_nfo.basins
     if basins isa SparseArray;
         throw(ArgumentError("""
             Sparse version of AttractorsViaRecurrences is incompatible with
@@ -234,10 +234,11 @@ function basins_of_attraction(mapper::AttractorsViaRecurrences; show_progress = 
     end
 
     # remove attractors and rescale from 1 to max number of attractors
+    bas_tmp = copy(basins)
     ind = iseven.(basins)
-    basins[ind] .+= 1
-    basins .= (basins .- 1) .÷ 2
-    return basins, mapper.bsn_nfo.attractors
+    bas_tmp[ind] .+= 1
+    bas_tmp .= (bas_tmp .- 1) .÷ 2
+    return bas_tmp, mapper.bsn_nfo.attractors
 end
 
 #####################################################################################

--- a/test/mapping/attractor_mapping.jl
+++ b/test/mapping/attractor_mapping.jl
@@ -71,6 +71,33 @@ function test_basins(ds, u0s, grid, expected_fs_raw, featurizer;
         test_basins_fractions(mapper; err = rerr)
     end
 
+
+    @testset "Basins of Attraction" begin 
+        # The reason of this test is to check whether 
+        # basins_of_attraction does not modify the internal 
+        # state of the mapper changing. (regression bug)
+        function map_3_states(z, p, n)
+            if z[1] < -1
+                return SVector(-2.0, 0.) 
+            elseif -1 ≤ z[1] ≤ 1
+                return SVector(0.0, 0.)
+            else 
+                return SVector(2.0, 0.)
+            end
+        end
+        ds = DiscreteDynamicalSystem(map_3_states, zeros(2)) 
+        xg = yg = range(-3, 3; length = 20) 
+        grid = (xg, yg)
+        mapper = AttractorsViaRecurrences(ds, grid; sparse = false)  
+        basins, atts = basins_of_attraction(mapper; show_progress = false)
+        ics = [ [x,1.0] for x in range(-3,3,length = 20)]
+        fractions, labels = basins_fractions(mapper, ics)
+
+        @test 0 ∉ keys(fractions)
+    end
+
+
+
     @testset "Featurizing, clustering" begin
         optimal_radius_method = "silhouettes_optim"
         config = GroupViaClustering(; num_attempts_radius=20, optimal_radius_method)


### PR DESCRIPTION
The bug described in #177 and patched in #178 had no test. 

This test sets up a simple map, runs `basins_of_attraction` with the `sparse = false`  option and the check whether basins_of_attraction has not compromised the mapper by changing the internal labels. 

I added a fix for the documentation compilation error. 