### PR TITLE
Update of StabilityMeasuresAccumulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.29
+
+- Keyword `metric` of `StabilityMeasuresAccumulator` is no longer used as it was incorrect.
+- New keyword `distance` for `StabilityMeasuresAccumulator`.
+- Source code of `StabilityMeasuresAccumulator` has been drastically simplified, and instructions for how to extent its functionality were added.
+
 # v1.28
 
 - `extract_attractors` will now automatically name the dimensions of the attractors for MTK-derived systems.

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Attractors"
 uuid = "f3fd9213-ca85-4dba-9dfd-7fc91308fec7"
 authors = ["George Datseris <datseris.george@gmail.com>", "Kalel Rossi", "Alexandre Wagemakers"]
 repo = "https://github.com/JuliaDynamics/Attractors.jl.git"
-version = "1.28.0"
+version = "1.29.0"
 
 
 [deps]

--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -296,12 +296,12 @@ series = {KDD'96}
 }
 
 @article{Morr2025,
-  title = {To be published},
-  author = {Andreas Morr, George Datseris},
-  journal = {},
-  volume = {},
-  number = {},
-  pages = {},
+  title = {Numerically Estimating Resilience Measures in Dynamical Systems},
+  author = {Andreas Morr, Christian Kuehn, George Datseris},
+  journal = {to be published},
+  volume = {1},
+  number = {1},
+  pages = {1},
   year = {2025},
 }
 

--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -297,7 +297,7 @@ series = {KDD'96}
 
 @article{Morr2025,
   title = {Numerically Estimating Resilience Measures in Dynamical Systems},
-  author = {Andreas Morr, Christian Kuehn, George Datseris},
+  author = {Andreas Morr and Christian Kuehn and George Datseris},
   journal = {to be published},
   volume = {1},
   number = {1},

--- a/ext/plotting.jl
+++ b/ext/plotting.jl
@@ -301,6 +301,10 @@ function Attractors.plot_continuation_curves!(ax, continuation_info, prange = 1:
     )
 
     series = continuation_series(continuation_info, NaN, ukeys)
+    for (k, v) in series
+        v[isinf.(v)] .= NaN
+    end
+    
     for k in ukeys
         scatterlines!(ax, prange, series[k];
             color = colors[k], label = "$(labels[k])", marker = markers[k],

--- a/src/continuation/continuation_stability_measures.jl
+++ b/src/continuation/continuation_stability_measures.jl
@@ -108,7 +108,7 @@ continuation steps.
 
 - `ε = nothing`: given to [`AttractorsViaProximity`](@ref).
 - `proximity_mapper_options = NamedTuple()`: extra keywords for `AttractorsViaProximity`.
-- `metric, finite_time, weighting_distribution`: given to [`StabilityMeasuresAccumulator`](@ref).
+- `distance, finite_time, weighting_distribution`: given to [`StabilityMeasuresAccumulator`](@ref).
 - `samples_per_parameter = 1000`: how many samples to use when estimating stability measures
   via [`StabilityMeasuresAccumulator`](@ref). Ignored when `ics` is not a function.
 """
@@ -121,7 +121,7 @@ function stability_measures_along_continuation(
         weighting_distribution = EverywhereUniform(),
         finite_time = 1.0,
         samples_per_parameter = 1000,
-        metric = Euclidean(),
+        distance = Centroid(),
         proximity_mapper_options = NamedTuple(),
         show_progress=true
     )
@@ -153,11 +153,18 @@ function stability_measures_along_continuation(
         else
             ft = finite_time
         end
-        
+        if distance isa AbstractVector
+            d = distance[i]
+        elseif distance isa Function
+            d = distance(p, attractors)
+        else
+            d = distance
+        end
+
         accumulator = StabilityMeasuresAccumulator(
             AttractorsViaProximity(ds, attractors; ε = ε_, proximity_mapper_options...);
             weighting_distribution=wd, finite_time=ft,
-            metric=metric
+            distance=d
         )
         N = ics isa Function ? samples_per_parameter : length(ics)
         for i ∈ 1:N

--- a/src/continuation/continuation_stability_measures.jl
+++ b/src/continuation/continuation_stability_measures.jl
@@ -130,16 +130,34 @@ function stability_measures_along_continuation(
     )
     measures_cont = []
     for (i, p) in enumerate(pcurve)
-        ε_ = ε isa AbstractVector ? ε[i] : ε # if its a vector, get i-th entry
-        weighting_distribution_ = weighting_distribution isa AbstractVector ?
-                                weighting_distribution[i] : weighting_distribution
-        finite_time_ = finite_time isa AbstractVector ? finite_time[i] : finite_time
         set_parameters!(ds, p)
         attractors = attractors_cont[i]
+        if ε isa AbstractVector
+            ε_ = ε[i]
+        elseif ε isa Function
+            ε_ = ε(p, attractors)
+        else
+            ε_ = ε
+        end
+        if weighting_distribution isa AbstractVector
+            wd = weighting_distribution[i]
+        elseif weighting_distribution isa Function
+            wd = weighting_distribution(p, attractors)
+        else
+            wd = weighting_distribution
+        end
+        if finite_time isa AbstractVector
+            ft = finite_time[i]
+        elseif finite_time isa Function
+            ft = finite_time(p, attractors)
+        else
+            ft = finite_time
+        end
+        
         accumulator = StabilityMeasuresAccumulator(
             AttractorsViaProximity(ds, attractors; ε = ε_, proximity_mapper_options...);
-            weighting_distribution = weighting_distribution_, finite_time = finite_time_,
-            metric = metric
+            weighting_distribution=wd, finite_time=ft,
+            metric=metric
         )
         N = ics isa Function ? samples_per_parameter : length(ics)
         for i ∈ 1:N

--- a/src/mapping/attractor_mapping_proximity.jl
+++ b/src/mapping/attractor_mapping_proximity.jl
@@ -69,6 +69,9 @@ function AttractorsViaProximity(ds::DynamicalSystem, attractors::Dict;
     if !(valtype(attractors) <: AbstractStateSpaceSet)
         error("The input attractors must be a dictionary with values of `StateSpaceSet`s.")
     end
+    if isempty(attractors)
+        error("The input attractors cannot be an empty dictionary.")
+    end
     if dimension(ds) ≠ dimension(first(attractors)[2])
         error("Dimension of the dynamical system and candidate attractors must match.")
     end

--- a/src/mapping/stability_measures_accumulator.jl
+++ b/src/mapping/stability_measures_accumulator.jl
@@ -206,6 +206,9 @@ function finalize_accumulator(accumulator::StabilityMeasuresAccumulator)
     bs = accumulator.bs
     cts = accumulator.cts
     N = length(u0s)
+    N == 0 && error("No initial conditions have been processed. Cannot finalize accumulator.")
+
+
 
     ws = [pdf(accumulator.weighting_distribution, u0[1]) for u0 in u0s]
 
@@ -301,9 +304,13 @@ function finalize_accumulator(accumulator::StabilityMeasuresAccumulator)
         median_convergence_pace[id] = weighted_median(cps_id, ws_id)
     end
 
-    minimal_critical_shock_magnitude = Dict(id => minimum(
-        d[i, ids_to_js[id]] for i in 1:length(accumulator.bs) 
-        if (accumulator.bs[i] != id && ws[i] > 0)) for id in ids
+    minimal_critical_shock_magnitude = Dict(
+        id => minimum(
+            (d[i, ids_to_js[id]] for i in eachindex(accumulator.bs)
+            if accumulator.bs[i] != id && ws[i] > 0);
+            init = Inf,
+        )
+        for id in ids
     )
     minimal_critical_shock_magnitude[-1] = NaN # no critical shock for -1 attractor
 

--- a/src/mapping/stability_measures_accumulator.jl
+++ b/src/mapping/stability_measures_accumulator.jl
@@ -146,7 +146,8 @@ function StabilityMeasuresAccumulator(mapper::AttractorMapper;
     V = typeof(current_state(ds))
     F = typeof(finite_time)
     M = typeof(distance)
-    StabilityMeasuresAccumulator{AM, V, F, M, typeof(weighting_distribution)}(
+    W = typeof(weighting_distribution)
+    StabilityMeasuresAccumulator{AM, V, F, M, W}(
         mapper,
         Vector{V}(),
         Vector{Int}(),

--- a/src/mapping/stability_measures_accumulator.jl
+++ b/src/mapping/stability_measures_accumulator.jl
@@ -84,10 +84,10 @@ Currently linear measures for discrete time systems are not computed.
 
 ### Nonlocal stability measures
 
-These nonlocal stability measures are accumulated while initial conditions are mapped
-to attractors. Afterwards they are averaged according to the probability density
-`weighting_distribution` when calling `finalize_accumulator!`. The word "distance" here
-refers to the distance established by the `metric` keyword.
+The information for these nonlocal stability measures is accumulated while initial
+conditions are mapped to attractors. Afterwards it is aggregated according to the
+probability density `weighting_distribution` when calling `finalize_accumulator!`. The word
+"distance" here refers to the distance established by the `metric` keyword.
 
 * `mean_convergence_time`: The convergence time is determined by the
   `mapper` using [`convergence_time`](@ref). The mean is computed with respect
@@ -95,9 +95,8 @@ refers to the distance established by the `metric` keyword.
 * `maximal_convergence_time`: The maximal convergence time of initial conditions
   to the attractor. Only initial conditions with non-zero probability under
   `weighting_distribution` are considered.
-* `median_convergence_time`: The median convergence time of initial conditions.
-  Only initial conditions with non-zero probability under `weighting_distribution`
-  are considered.
+* `median_convergence_time`: The median convergence time of initial conditions under the
+  `weighting_distribution`.
 * `mean_convergence_pace`: The mean convergence pace of initial conditions to
   the attractor. Similar to the mean convergence time, except that each
   convergence time is divided by the distance of the respective initial
@@ -105,9 +104,8 @@ refers to the distance established by the `metric` keyword.
 * `maximal_convergence_pace`: The maximal convergence pace of initial conditions
   to the attractor. Only initial conditions with non-zero probability under
   `weighting_distribution` are considered.
-* `median_convergence_pace`: The median convergence pace of initial conditions.
-  Only initial conditions with non-zero probability under `weighting_distribution`
-  are considered.
+* `median_convergence_pace`: The median convergence pace of initial conditions under the
+  `weighting_distribution`.
 * `minimal_critical_shock_magnitude`: The minimal distance of the attractor to the
   closest non-zero probability point (under `weighting_distribution`) in a basin of
   attraction of a different attractor. If only a single attractor exists,
@@ -115,7 +113,8 @@ refers to the distance established by the `metric` keyword.
 * `maximal_noncritical_shock_magnitude`: The distance of the attractor to the
   furthest non-zero probability point (under `weighting_distribution`) of its own basin of
   attraction. If only a single attractor exists, the value `Inf` is assigned.
-* `mean_noncritical_shock_magnitude`: same as above but the mean instead of maximum distance.
+* `mean_noncritical_shock_magnitude`: same as above but computing the mean under
+  `weighting_distribution` instead of maximum distance.
 * `basin_fraction`: The fraction of initial conditions that converge to the
   attractor.
 * `basin_stability`: The fraction of initial conditions that converge to the

--- a/src/mapping/stability_measures_accumulator.jl
+++ b/src/mapping/stability_measures_accumulator.jl
@@ -209,6 +209,36 @@ end
 # Function to update the accumulator with a new state
 function (accumulator::StabilityMeasuresAccumulator)(u0; show_progress = false)
     id = accumulator.mapper(u0)
+
+    push!(accumulator.u0s, u0)
+    push!(accumulator.basins, id)
+    push!(accumulator.times, convergence_time(accumulator.mapper))
+
+end
+
+function finalize yada yada
+    # first step is to compute the d_{i,j} "matrix"
+    attractors = extract_attractors(accumulator.mapper)
+    ids = keys(attractors)
+    js = 1:length(keys)
+    # create inverse
+    ids_to_js = [somehow estimate this]
+
+
+    id = ids[j]
+
+    d = zeros(length(u0s), length(js))
+    for j in js
+      for i in 1:length(u0s)
+        d[i, j] = set_distance(u0, attractors[ids[j]])
+      end
+    end
+
+
+
+    # DELETE EVERYTHING BELOW THIS LINE!
+
+
     if (isa(accumulator.mapper, AttractorsViaProximity) && accumulator.mapper.ε != nothing)
       ε = accumulator.mapper.ε
     else
@@ -280,7 +310,7 @@ function (accumulator::StabilityMeasuresAccumulator)(u0; show_progress = false)
             push!(accumulator.nonzero_measure_basin_points[id], u0)
         end
 
-        for id2 in keys(attractors) 
+        for id2 in keys(attractors)
           if id2 != id
             thisdist = set_distance(
                 StateSpaceSet([u0]), attractors[id2],
@@ -313,7 +343,7 @@ function (accumulator::StabilityMeasuresAccumulator)(u0; show_progress = false)
             )
         end
 
-        
+
     end
 
     return id

--- a/src/mapping/stability_measures_accumulator.jl
+++ b/src/mapping/stability_measures_accumulator.jl
@@ -125,14 +125,14 @@ refers to the distance established by the `metric` keyword.
   converge to the attractor within the time horizon `finite_time`, weighted by
   `weighting_distribution`.
 """
-mutable struct StabilityMeasuresAccumulator{AM<:AttractorMapper, Dims, Datatype, V<:AbstractVector} <: AttractorMapper
+mutable struct StabilityMeasuresAccumulator{AM<:AttractorMapper, V<:AbstractVector, F, M} <: AttractorMapper
     mapper::AM
     u0s::Vector{V}
     bs::Vector{Int}
     cts::Vector{Float64}
-    finite_time::Float64 # Discussed that this should be F and metric::M but this leads to errors...
+    finite_time::F
     weighting_distribution::Union{EverywhereUniform, Distribution}
-    metric::Metric
+    metric::M
 end
 
 function StabilityMeasuresAccumulator(mapper::AttractorMapper;
@@ -141,10 +141,10 @@ function StabilityMeasuresAccumulator(mapper::AttractorMapper;
     reset_mapper!(mapper)
     ds = referenced_dynamical_system(mapper)
     AM = typeof(mapper)
-    Dims = dimension(ds)
-    Datatype = eltype(current_state(ds))
     V = typeof(current_state(ds))
-    StabilityMeasuresAccumulator{AM, Dims, Datatype, V}(
+    F = typeof(finite_time)
+    M = typeof(metric)
+    StabilityMeasuresAccumulator{AM, V, F, M}(
         mapper,
         Vector{V}(),
         Vector{Int}(),
@@ -159,8 +159,6 @@ end
 function reset_mapper!(a::StabilityMeasuresAccumulator)
     reset_mapper!(a.mapper)
     ds = referenced_dynamical_system(a.mapper)
-    Dims = dimension(ds)
-    Datatype = eltype(current_state(ds))
     V = typeof(current_state(ds))
     a.u0s = Vector{V}()
     a.bs = Vector{Int}()

--- a/src/mapping/stability_measures_accumulator.jl
+++ b/src/mapping/stability_measures_accumulator.jl
@@ -57,11 +57,17 @@ more rirogously and is estimated more accurately for a proximity mapper.
 ## Description
 
 `StabilityMeasuresAccumulator` efficiently uses a single `id = mapper(u0)` call
-to accumulate information for many differnt stability measures corresponding
+to accumulate information for many different stability measures corresponding
 to each attractor of the dynamical system.
 It accumulates all these different measures when different initial conditions
 are mapped through it. After enough `u0`s have been given to the accumulator, they
 can be finalized (comput maxima or averages) using `finalize!(accumulator)`.
+
+You can extent this functionality by adding new stability measures as long as their
+estimation can be done on the basis of the three quantities accumulated:
+the basin dictionary mapping initial conditions to attractors,
+the distance of each initial condition to each attractor,
+and the convergence time of each initial condition.
 
 The following stability measures are estimated for each attractor
 (and the returned dictionary maps strings with the names of the measures

--- a/src/mapping/stability_measures_accumulator.jl
+++ b/src/mapping/stability_measures_accumulator.jl
@@ -345,9 +345,14 @@ function finalize_accumulator(accumulator::StabilityMeasuresAccumulator)
                 maximal_amplification_time[id] = Inf
             else
                 f(t) = -opnorm(exp(t*J))
-                T = range(0.0, 1000*characteristic_return_time[id], length=2001)
-                t0 = argmin(f.(T))
-                res = Optim.optimize(f, max(0.0, t0-5), min(1000.0, t0+5), Brent())
+                T = range(0.0, 10*characteristic_return_time[id], length=20001)
+                step_length = T[2] - T[1]
+                t0 = T[argmin(f.(T))]
+                if t0 == 10*characteristic_return_time[id] # maximum is at the end
+                  res = Optim.optimize(f, t0, t0 + 100*characteristic_return_time[id], Brent())
+                else
+                  res = Optim.optimize(f, max(0.0, t0-step_length), t0+step_length, Brent())
+                end
                 maximal_amplification[id] = (-1) * Optim.minimum(res)
                 maximal_amplification_time[id] = Optim.minimizer(res)[1]
             end

--- a/test/mapping/stability_measures_accumulator.jl
+++ b/test/mapping/stability_measures_accumulator.jl
@@ -47,9 +47,6 @@ results = finalize_accumulator(accumulator)
 # that point and the furthest point of its own basin at [0, -1] which is 2.23607. For
 # attractor 1 at [-1, -1] the maximal noncritical shock is 2.0, which is the distance to the
 # point [-1, 1] which is the furthest point in its basin.
-# Keep in mind that initial conditions that are the attractor itself have a convergence time
-# of 0.0. Medians are computed as the mean between the two middle values if the number of
-# values is even.
 
 results_expected = Dict(
     "mean_convergence_time"            => Dict(2=>0.22222, 1=>0.55555, -1=>NaN),

--- a/test/mapping/stability_measures_accumulator.jl
+++ b/test/mapping/stability_measures_accumulator.jl
@@ -42,41 +42,52 @@ end
 
 results = finalize_accumulator(accumulator)
 
-# The expected results are:
+# The expected results are computed as in the following example:
 # maximal_noncritical_shock of attractor 2 at [1, 1] is computed as the distance between the
 # that point and the furthest point of its own basin at [0, -1] which is 2.23607. For
 # attractor 1 at [-1, -1] the maximal noncritical shock is 2.0, which is the distance to the
 # point [-1, 1] which is the furthest point in its basin.
-# Similarly, the median convergence pace is the constant convergence time 1.0 divided by the
-# distance to the point of median distance in the basin. For attractor 2, there are an even
-# number of basin points, so the median is the mean of the two middle values. Here,
-# 1.0 / 1.41421 = 0.707106 and 1.0 / 1.0, so 0.85355 for the points at [0,0] and [1, 0] for
-# example.
+# Keep in mind that initial conditions that are the attractor itself have a convergence time
+# of 0.0. Medians are computed as the mean between the two middle values if the number of
+# values is even.
+
 results_expected = Dict(
-    "mean_convergence_time"            => Dict(2=>1.0, 1=>1.0),
-    "maximal_noncritical_shock_magnitude" => Dict(2=>2.23607, 1=>2.0),
-    "finite_time_basin_stability"      => Dict(2=>0.0, 1=>0.0),
-    "median_convergence_pace"          => Dict(2=>0.85355, 1=>1.0),
-    "median_convergence_time"          => Dict(2=>1.0, 1=>1.0),
-    "minimal_critical_shock_magnitude"    => Dict(2=>2.0, 1=>1.0),
-    "basin_stability"                  => Dict(2=>0.66667, 1=>0.33333),
-    "maximal_convergence_pace"         => Dict(2=>Inf, 1=>Inf),
-    "maximal_convergence_time"         => Dict(2=>1.0, 1=>1.0),
-    "mean_convergence_pace"            => Dict(2=>Inf, 1=>Inf),
-    "basin_fraction"                   => Dict(2=>0.66667, 1=>0.33333)
+    "mean_convergence_time"            => Dict(2=>0.22222, 1=>0.55555, -1=>NaN),
+    "maximal_noncritical_shock_magnitude" => Dict(2=>2.23607, 1=>2.0, -1=>NaN),
+    "finite_time_basin_stability"      => Dict(2=>0.11111, 1=>0.11111, -1=>0.0),
+    "median_convergence_pace"          => Dict(2=>0.5, 1=>0.5, -1=>NaN),
+    "median_convergence_time"          => Dict(2=>1.0, 1=>1.0, -1=>NaN),
+    "minimal_critical_shock_magnitude"    => Dict(2=>2.0, 1=>1.0, -1=>NaN),
+    "basin_stability"                  => Dict(2=>0.66667, 1=>0.33333, -1=>0.0),
+    "maximal_convergence_pace"         => Dict(2=>1.0, 1=>1.0, -1=>NaN),
+    "maximal_convergence_time"         => Dict(2=>1.0, 1=>1.0, -1=>NaN),
+    "mean_convergence_pace"            => Dict(2=>0.16667, 1=>0.40604, -1=>NaN),
+    "basin_fraction"                   => Dict(2=>0.66667, 1=>0.33333, -1=>0.0),
+    "mean_noncritical_shock_magnitude" => Dict(2=>0.33333, 1=>0.85003, -1=>NaN),
+    "characteristic_return_time"       => Dict(2=>NaN, 1=>NaN, -1=>NaN),
+    "reactivity"                       => Dict(2=>NaN, 1=>NaN, -1=>NaN),
+    "maximal_amplification"           => Dict(2=>NaN, 1=>NaN, -1=>NaN),
+    "maximal_amplification_time"      => Dict(2=>NaN, 1=>NaN, -1=>NaN)
 )
 # Check if the results are as expected
 @testset "Nonlocal Stability Measures Accumulator with dumb map" begin
     for (key, value) in results_expected
         @test key in keys(results)
-        @test sort(collect(values(value))) ≈ sort(collect(values(results[key]))) atol=1e-5
+        @test isapprox(
+            sort(collect(values(value))),
+            sort(collect(values(results[key])));
+            atol = 1e-5,
+            nans = true,
+        )
     end
 end
 
 # Now we test the continuation of nonlocal stability measures.
 pcurve = [[1 => p] for p in [-1.0, 1.0]]
-acam = AttractorSeedContinueMatch(accumulator, MatchBySSSetDistance(), seeding=A->[])
-measures_cont, attractors_cont = global_continuation(acam, pcurve, ics_from_grid(grid))
+attractors_cont = [
+    Dict(1 => StateSpaceSet([SVector(0.0, 0.0)])),
+    Dict(2 => StateSpaceSet([SVector(1.0, 1.0)]), 1 => StateSpaceSet([SVector(-1.0, -1.0)]))
+]
 
 proximity_mapper_options = (
     Ttr=0, stop_at_Δt = false, horizon_limit = 1e2, consecutive_lost_steps = 10000
@@ -87,24 +98,34 @@ measures_cont = stability_measures_along_continuation(
 )
 
 measures_cont_expected = Dict(
-    "finite_time_basin_stability"      => [Dict(1=>0.0), Dict(2=>0.0, 1=>0.0)],
-    "maximal_noncritical_shock_magnitude" => [Dict(1=>Inf), Dict(2=>2.0, 1=>2.23607)],
-    "median_convergence_pace"          => [Dict(1=>1.0), Dict(2=>1.0, 1=>0.85355)],
-    "basin_stability"                  => [Dict(1=>1.0), Dict(2=>0.33333, 1=>0.66667)],
-    "maximal_convergence_pace"         => [Dict(1=>Inf), Dict(2=>Inf, 1=>Inf)],
-    "mean_convergence_pace"            => [Dict(1=>Inf), Dict(2=>Inf, 1=>Inf)],
-    "basin_fraction"                   => [Dict(1=>1.0), Dict(2=>0.33333, 1=>0.66667)],
-    "mean_convergence_time"            => [Dict(1=>1.0), Dict(2=>1.0, 1=>1.0)],
-    "minimal_critical_shock_magnitude"    => [Dict(1=>Inf), Dict(2=>1.0, 1=>2.0)],
-    "median_convergence_time"          => [Dict(1=>1.0), Dict(2=>1.0, 1=>1.0)],
-    "maximal_convergence_time"         => [Dict(1=>1.0), Dict(2=>1.0, 1=>1.0)],
+    "finite_time_basin_stability"      => [Dict(1=>0.11111, -1=>0.0), Dict(2=>0.11111, 1=>0.11111, -1=>0.0)],
+    "maximal_noncritical_shock_magnitude" => [Dict(1=>1.41421, -1=>NaN), Dict(2=>2.23607, 1=>2.0, -1=>NaN)],
+    "median_convergence_pace"          => [Dict(1=>0.70711, -1=>NaN), Dict(2=>0.5, 1=>0.5, -1=>NaN)],
+    "basin_stability"                  => [Dict(1=>1.0, -1=>0.0), Dict(2=>0.66667, 1=>0.33333, -1=>0.0)],
+    "maximal_convergence_pace"         => [Dict(1=>1.0, -1=>NaN), Dict(2=>1.0, 1=>1.0, -1=>NaN)],
+    "mean_convergence_pace"            => [Dict(1=>0.75871, -1=>NaN), Dict(2=>0.40604, 1=>0.16667, -1=>NaN)],
+    "basin_fraction"                   => [Dict(1=>1.0, -1=>0.0), Dict(2=>0.66667, 1=>0.33333, -1=>0.0)],
+    "mean_convergence_time"            => [Dict(1=>0.88889, -1=>NaN), Dict(2=>0.22222, 1=>0.55555, -1=>NaN)],
+    "minimal_critical_shock_magnitude"    => [Dict(1=>Inf, -1=>NaN), Dict(2=>2.0, 1=>1.0, -1=>NaN)],
+    "median_convergence_time"          => [Dict(1=>1.0, -1=>NaN), Dict(2=>1.0, 1=>1.0, -1=>NaN)],
+    "maximal_convergence_time"         => [Dict(1=>1.0, -1=>NaN), Dict(2=>1.0, 1=>1.0, -1=>NaN)],
+    "mean_noncritical_shock_magnitude" => [Dict(1=>1.07298, -1=>NaN), Dict(2=>0.33333, 1=>0.85003, -1=>NaN)],
+    "characteristic_return_time"       => [Dict(1=>NaN, -1=>NaN), Dict(2=>NaN, 1=>NaN, -1=>NaN)],
+    "reactivity"                       => [Dict(1=>NaN, -1=>NaN), Dict(2=>NaN, 1=>NaN, -1=>NaN)],
+    "maximal_amplification"           => [Dict(1=>NaN, -1=>NaN), Dict(2=>NaN, 1=>NaN, -1=>NaN)],
+    "maximal_amplification_time"      => [Dict(1=>NaN, -1=>NaN), Dict(2=>NaN, 1=>NaN, -1=>NaN)]
 )
 @testset "Nonlocal Stability Measures Continuation" begin
     # Validate the results
     for (key, value) in measures_cont_expected
         @test key in keys(measures_cont)
         for k in [1, 2]
-            @test sort(collect(values(value[k]))) ≈ sort(collect(values(results[key][k]))) atol=1e-5
+            @test isapprox(
+                sort(collect(values(value[k]))),
+                sort(collect(values(measures_cont[key][k]))),
+                atol = 1e-5,
+                nans = true,
+            )
         end
     end
 end
@@ -135,16 +156,21 @@ results = finalize_accumulator(accumulator)
 
 # Define expected results for the linear system
 results_expected = Dict(
-    "characteristic_return_time" => Dict(1 => 2.0),
-    "reactivity"       => Dict(1 => -0.5),
-    "maximal_amplification" => Dict(1 => 1.0),
-    "maximal_amplification_time" => Dict(1 => 0.0)
+    "characteristic_return_time" => Dict(1 => 2.0, -1 => NaN),
+    "reactivity"       => Dict(1 => -0.5, -1 => NaN),
+    "maximal_amplification" => Dict(1 => 1.0, -1 => NaN),
+    "maximal_amplification_time" => Dict(1 => 0.0, -1 => NaN)
 )
 @testset "Local Stability Measures Accumulator" begin
     # Validate the results
     for (key, value) in results_expected
         @test key in keys(results)
-        @test sort(collect(values(value))) ≈ sort(collect(values(results[key]))) atol=1e-5
+        @test isapprox(
+            sort(collect(values(value))),
+            sort(collect(values(results[key])));
+            atol = 1e-5,
+            nans = true,
+        )
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,6 +18,7 @@ testfile(file, testname=defaultname(file)) = @testset "$testname" begin; include
         testfile("mapping/basins_of_attraction.jl")
         testfile("mapping/histogram_grouping.jl")
         testfile("mapping/irregular_grid.jl")
+        testfile("mapping/stability_measures_accumulator.jl")
     end
 
     @testset "basins analysis" begin


### PR DESCRIPTION
This refactoring makes the computation of stability measures in the StabilityMeasuresAccumulator framework more resource efficient. It also fixes several bugs, such as problems with empty basins of attraction.