### PR TITLE
Relaxed basinsinfo inner constructor

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Attractors"
 uuid = "f3fd9213-ca85-4dba-9dfd-7fc91308fec7"
 authors = ["George Datseris <datseris.george@gmail.com>", "Kalel Rossi", "Alexandre Wagemakers"]
 repo = "https://github.com/JuliaDynamics/Attractors.jl.git"
-version = "1.31.2"
+version = "1.31.3"
 
 [deps]
 BlackBoxOptim = "a134a8b2-14d6-55f6-9291-3336d3ab0209"

--- a/src/mapping/recurrences/attractor_mapping_recurrences.jl
+++ b/src/mapping/recurrences/attractor_mapping_recurrences.jl
@@ -248,8 +248,8 @@ end
 #####################################################################################
 
 mutable struct BasinsInfo{
-        D, Δ, T, V, G <: Grid, B <: AbstractArray{Int, D},
-        A <: ArrayBasinsOfAttraction{Int, D, B, T, V, G},
+        D, Δ, B <: AbstractArray{Int, D},
+        A <: ArrayBasinsOfAttraction{Int, D, B},
     }
     BoA::A # sparse or dense
     Δt::Δ


### PR DESCRIPTION
Minor change, relaxing the `BasinsInfo` inner constructor to fix errors when using `AttractorsViaRecurrences` as seen in  #194  and also test failures.

Original error caused by over-specifying the `ArrayBasinsOfAttraction` constructor, which was partially fixed in commit [cfc9377](https://github.com/JuliaDynamics/Attractors.jl/commit/cfc937782f3e48ac03b6dd678d230a3b7ec63d13) but the `BasinsInfo` constructor which relies on that type wasn't updated, which caused errors like in #194.