### PR TITLE
Rename stability measures to quantifiers

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -207,12 +207,12 @@ swap_dict_keys!
 next_free_id
 ```
 
-## Stability measures/quantifiers
+## Stability quantifiers
 
 ```@docs
-StabilityMeasuresAccumulator
+StabilityQuantifiersAccumulator
 finalize_accumulator
-stability_measures_along_continuation
+stability_quantifiers_along_continuation
 ```
 
 ### Intermingledness

--- a/docs/src/bfkit_comparison.jl
+++ b/docs/src/bfkit_comparison.jl
@@ -221,9 +221,9 @@ mapper = BasinMapRecurrences(
 
 sampler, = statespace_sampler(grid)
 
-algo = AttractorSeedContinueMatch(StabilityMeasuresAccumulator(mapper))
+algo = AttractorSeedContinueMatch(StabilityQuantifiersAccumulator(mapper))
 
-@time measures_cont, attractors_cont = global_continuation(
+@time quantifiers_cont, attractors_cont = global_continuation(
     algo, prange, pidx, sampler; samples_per_parameter = 1_000
 )
 
@@ -251,7 +251,7 @@ plot_attractors_curves(
 # These algorithms are also robust in the sense of working well for
 # many different types of dynamical systems, including discrete ones,
 # see [Datseris2022](@cite) for a demonstration.
-# And finally, Attractors.jl estimates a more general nonlocal measure of stability,
+# And finally, Attractors.jl estimates a more general nonlocal quantifier of stability,
 # in the sense that if a set is nonlocally stable, it is guaranteed to be locally stable,
 # however the other way around isn't guaranteed.
 # The global continuation of Attractors.jl continues the whole of a

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -716,9 +716,9 @@ computing the zeroes of the ODE system. However, the edge tracking algorithm all
 edge states also in high-dimensional and chaotic systems where a simple computation of
 unstable equilibria becomes infeasible.
 
-## Estimating (almost) all stability measures using the accumulator
+## Estimating (almost) all stability quantifiers using the accumulator
 
-The type [`StabilityMeasuresAccumulator`](@ref) which was highlighted in the main tutorial is showcased in an application of finding all stability measures for the Duffing oscillator at a fixed parameter here.
+The type [`StabilityQuantifiersAccumulator`](@ref) which was highlighted in the main tutorial is showcased in an application of finding all stability quantifiers for the Duffing oscillator at a fixed parameter here.
 
 ```@example MAIN
 function duffing(u, p, t)
@@ -740,25 +740,25 @@ grid = (range(-2, 2; length = n_grid),range(-2, 2; length = n_grid),)
 
 mapper = BasinMapRecurrences(ds, grid; sparse = false, consecutive_recurrences = 1000)
 
-accumulator = StabilityMeasuresAccumulator(mapper;
+accumulator = StabilityQuantifiersAccumulator(mapper;
     finite_time = 50.0, weighting_distribution = MvNormal(zeros(2), 1.0*I)
 )
 ```
 
 If we call this object on some initial conditions and finalize its values, we receive
-several different stability measures. Their interpretation can be found in the documentation of [`StabilityMeasuresAccumulator`](@ref).
+several different stability quantifiers. Their interpretation can be found in the documentation of [`StabilityQuantifiersAccumulator`](@ref).
 
 ```@example MAIN
 ics = ics_from_grid(grid)
 for u0 in ics
     id = accumulator(u0)
 end
-stability_measures = finalize_accumulator(accumulator)
+stability_quantifiers = finalize_accumulator(accumulator)
 ```
 
 ## [Enhancing the accumulator with arbitrary user-defined quantifiers](@id user_defined_quantifiers)
 
-Following from the example above, lets' say that we want to enhance the accumulator with another quantity which is not estimated by default. In this example this will simply be the maximum velocity (2nd variable) each basin has. Following the documentation of [`StabilityMeasuresAccumulator`](@ref), we only need to define a function that inputs a [`SampledBasinsOfAttraction`](@ref) and returns a dictionary mapping attractor IDs to their additional quantifier. We can do this like so:
+Following from the example above, lets' say that we want to enhance the accumulator with another quantity which is not estimated by default. In this example this will simply be the maximum velocity (2nd variable) each basin has. Following the documentation of [`StabilityQuantifiersAccumulator`](@ref), we only need to define a function that inputs a [`SampledBasinsOfAttraction`](@ref) and returns a dictionary mapping attractor IDs to their additional quantifier. We can do this like so:
 
 ```@example MAIN
 function extra_function(sboa::SampledBasinsOfAttraction, ds::DynamicalSystem)
@@ -780,14 +780,14 @@ extras = Dict("maxv" => extra_function)
 we now pass this to a new accumulator and re-run everything:
 
 ```@example MAIN
-accumulator = StabilityMeasuresAccumulator(mapper, extras;
+accumulator = StabilityQuantifiersAccumulator(mapper, extras;
     finite_time = 50.0, weighting_distribution = MvNormal(zeros(2), 1.0*I)
 )
 for u0 in ics
     id = accumulator(u0)
 end
-stability_measures = finalize_accumulator(accumulator)
-stability_measures["maxv"]
+stability_quantifiers = finalize_accumulator(accumulator)
+stability_quantifiers["maxv"]
 ```
 
 Unsurprisingly, the maximum value of the `y` coordinate is ≈2 for all basins, but this we new already due to the symmetries of the system's basins!
@@ -901,13 +901,13 @@ This special `matcher` achieves the following:
 
 
 
-## [Aggregated stability measures of a population model](@id aggregate_continuation_example)
+## [Aggregated stability quantifiers of a population model](@id aggregate_continuation_example)
 
 This example discusses aggregation of continuation results: where a dynamical system may have multiple attractors, but some of them share the same functional/operating state for the context of the system. In such cases, you want to aggregate attractors with similar function.
 The recommended recipe to do this is: run a normal
 [`global_continuation`](@ref) to find attractors, merge the attractors into user defined groups
 with [`aggregate_continuation`](@ref), and feed the merged attractors to
-[`stability_measures_along_continuation`](@ref) for the computation of stability measures.
+[`stability_quantifiers_along_continuation`](@ref) for the computation of stability quantifiers.
 
 We use the two-habitat population model with Allee effect, also featured in Schoenmakers and
 Feudel [Schoenmakers2021](@cite). The state `X = (X₁, X₂)` are the (normalised) population
@@ -975,11 +975,11 @@ agg_attractors_cont, centroids_cont, members_cont = aggregate_continuation(
 members_cont
 ```
 
-We then pass the merged attractors to [`stability_measures_along_continuation`](@ref).
+We then pass the merged attractors to [`stability_quantifiers_along_continuation`](@ref).
 Each group is treated as a single attractor, so its basin fraction is the total fraction of state space leading to it.
 
 ```@example MAIN
-measures_cont = stability_measures_along_continuation(
+quantifiers_cont = stability_quantifiers_along_continuation(
     ds, agg_attractors_cont, pcurve, sampler;
     ε = 0.05, finite_time = 100.0, show_progress = false
 )
@@ -987,14 +987,14 @@ measures_cont = stability_measures_along_continuation(
 # The extinction group is the one whose feature centroid is 1
 extinct_id = only(id for (id, c) in centroids_cont[end] if c[1] > 0.5)
 alive_id   = only(id for (id, c) in centroids_cont[end] if c[1] < 0.5)
-fig = plot_basins_curves(measures_cont["basin_fraction"], prange;
+fig = plot_basins_curves(quantifiers_cont["basin_fraction"], prange;
     colors = Dict(extinct_id => "black", alive_id => "green"),
     labels = Dict(extinct_id => "extinct", alive_id => "functioning"),
 )
 
-# `measures_cont` holds every other stability measure too
+# `quantifiers_cont` holds every other stability quantifier too
 ax = Axis(fig[0,1]; ylabel = "mct")
-plot_continuation_curves!(ax, measures_cont["mean_convergence_time"], prange;
+plot_continuation_curves!(ax, quantifiers_cont["mean_convergence_time"], prange;
     colors = Dict(extinct_id => "black", alive_id => "green"),
     labels = Dict(extinct_id => "extinct", alive_id => "functioning"),
 )

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -12,7 +12,7 @@ using CairoMakie, Attractors
 
 - Attractors found by a global continuation can be aggregated into user-defined groups with
   `aggregate_continuation` (or `aggregate_attractors` for a single parameter) before computing
-  stability measures via `stability_measures_along_continuation`.
+  stability quantifiers via `stability_quantifiers_along_continuation`.
 - **v1.36**: Three enhancements to `StabilityMeasuresAccumulator`:
   (1) local stability measures are now estimated for discrete-time systems too;
   (2) attractors can be aggregated before computing measures via `featurizer`/`group_config`
@@ -20,7 +20,7 @@ using CairoMakie, Attractors
   (3) `finalize_accumulator` now returns the (possibly aggregated) attractors as a second
   value so callers always have access to the correct IDs.
   See the CHANGELOG for details.
-- Yet another groundbreaking feature has been implemented in Attractors.jl: estimation of extendably-many stability measures of a dynamical system automatically, with a single function call (also works along a global continuation)
+- Yet another groundbreaking feature has been implemented in Attractors.jl: estimation of extendably-many stability quantifiers of a dynamical system automatically, with a single function call (also works along a global continuation)
 - See the CHANGELOG.md (at the GitHub repo) for more!
 
 ## Getting started

--- a/docs/src/tutorial.jl
+++ b/docs/src/tutorial.jl
@@ -499,35 +499,35 @@ animate_attractors_continuation(
 # ```
 
 # %% #src
-# ## Enhancing the continuation with more stability measures or other quantities
+# ## Enhancing the continuation with more stability quantifiers or other quantities
 
-# The standard stability measure that is reported during a global continuation
+# The standard stability quantifier that is reported during a global continuation
 # is the basin fractions. This is primarily because it is computed automatically
-# as we find the different attractors. There are many more stability measures
+# as we find the different attractors. There are many more stability quantifiers
 # that could be more useful in different contexts. Attractors.jl offers
-# the unique possibility of estimating _almost all_ known measures of stability in the
+# the unique possibility of estimating _almost all_ known quantifiers of stability in the
 # literature of dynamical systems during a _single_ global continuation pass.
-# This is done with the [`StabilityMeasuresAccumulator`](@ref) data structure.
-# You can visit its documentation string to learn about all different stability measures.
-# If you find some stability measures not included in the [`StabilityMeasuresAccumulator`](@ref)
+# This is done with the [`StabilityQuantifiersAccumulator`](@ref) data structure.
+# You can visit its documentation string to learn about all different stability quantifiers.
+# If you find some stability quantifiers not included in the [`StabilityQuantifiersAccumulator`](@ref)
 # then either open an Issue and tell us about it or even better make a Pull Request and
 # contribute it yourself!
 
-# Using [`StabilityMeasuresAccumulator`](@ref) is very easy. If we have already performed
-# a global continuation then we can utilize the function [`stability_measures_along_continuation`](@ref)
-# to run through it again and estimate now all stability measures.
+# Using [`StabilityQuantifiersAccumulator`](@ref) is very easy. If we have already performed
+# a global continuation then we can utilize the function [`stability_quantifiers_along_continuation`](@ref)
+# to run through it again and estimate now all stability quantifiers.
 
-result = stability_measures_along_continuation(
+result = stability_quantifiers_along_continuation(
     ds, attractors_cont, pcurve, sampler; ε = 0.1
 )
 keys(result)
 
-# The result is a dictionary mapping the stability measure name (as a string) to
-# the continuation of the measure.
-# We can see there are quite a lot of measures that have been estimated!
+# The result is a dictionary mapping the stability quantifier name (as a string) to
+# the continuation of the quantifier.
+# We can see there are quite a lot of quantifiers that have been estimated!
 # So the values of `result` are the same type as
 # the `fractions_cont` we have computed before. This means it is straightforward to
-# visualize these new stability measures. For example, let's say we want to visualize
+# visualize these new stability quantifiers. For example, let's say we want to visualize
 
 chosen = ["median_convergence_pace", "minimal_critical_shock_magnitude"]
 abbrev = ["MCP", "MCS"]
@@ -538,19 +538,19 @@ ukeys = unique_keys(attractors_cont) # so that we ignore key -1 (divergent orbit
 fig = plot_attractors_curves(attractors_cont, A -> minimum(A[:, 1]), θs)
 for (i, c) in enumerate(chosen)
     ax = Axis(fig[1 - i, 1]; ylabel = abbrev[i])
-    measure_cont = result[c]
-    plot_continuation_curves!(ax, measure_cont, θs; ukeys, add_legend = false)
+    quantifier_cont = result[c]
+    plot_continuation_curves!(ax, quantifier_cont, θs; ukeys, add_legend = false)
     hidexdecorations!(ax; grid = false)
 end
 resize!(fig, 600, 500)
 fig
 
-# For more specialization on estimating these stability measures,
-# see the documentation of [`StabilityMeasuresAccumulator`](@ref).
+# For more specialization on estimating these stability quantifiers,
+# see the documentation of [`StabilityQuantifiersAccumulator`](@ref).
 
 # One of the biggest strengths of Attractors.jl is that it is not an isolated software.
 # It is part of **DynamicalSystems.jl**. We can straightforwardly use any other
-# functionality of the library to enhance this continuation, even beyond stability measures.
+# functionality of the library to enhance this continuation, even beyond stability quantifiers.
 # Let's also estimate and visualize the maximum Lyapunov exponent for each attractor.
 # We first import the function that estimates the MLE
 
@@ -574,7 +574,7 @@ end
 
 # Notice: in the example here we we computed the Lyapunov exponents after the fact.
 # We could do it however duing the first-pass of the continuation of the
-# [`StabilityMeasuresAccumulator`](@ref) by providing the `extras` argument to it,
+# [`StabilityQuantifiersAccumulator`](@ref) by providing the `extras` argument to it,
 # see e.g., the [example of additional quantifiers](@ref user_defined_quantifiers) online.
 
 # Regardless, we now visualize the MLE with the same way as any other quantity over the continuation:

--- a/src/continuation/aggregate_continuation.jl
+++ b/src/continuation/aggregate_continuation.jl
@@ -48,18 +48,18 @@ set-distance accepted by [`setsofsets_distances`](@ref) (e.g. [`Hausdorff`](@ref
 sets. Because matching is in feature space, `featurizer` must return *numeric* feature vectors
 (e.g. `SVector`s).
 
-## Aggregating stability measures
+## Aggregating stability quantifiers
 
-To obtain stability measures for the aggregated groups, pass
-`agg_attractors_cont` to [`stability_measures_along_continuation`](@ref). Each merged group is
-then treated as a single attractor, so every measure — including those that need the raw basin
+To obtain stability quantifiers for the aggregated groups, pass
+`agg_attractors_cont` to [`stability_quantifiers_along_continuation`](@ref). Each merged group is
+then treated as a single attractor, so every quantifier — including those that need the raw basin
 data, such as medians and critical shock magnitudes — is computed correctly for the group.
 
 See the [aggregation example](@ref aggregate_continuation_example) for an illustration.
 
 !!! note "Aggregating basin fractions only"
     If you only care about aggregating the basin fractions, there is no reason to
-    go through the route of `stability_measures_along_continuation`.
+    go through the route of `stability_quantifiers_along_continuation`.
     Simply give the returned `members_cont`, together with the `fractions_cont` from the
     continuation, to [`aggregate_fractions`](@ref).
     The denser the sampling for the original continuation was, the more accurate
@@ -114,8 +114,8 @@ are merged into a single `StateSpaceSet`.
 3. `members`: a dictionary mapping each group ID to the vector of original attractor IDs (the keys
    of `attractors`) that were merged into it.
 
-To compute stability measures for the merged groups, pass `agg_attractors` to
-[`stability_measures_along_continuation`](@ref) (wrapping it and the parameter in length-1
+To compute stability quantifiers for the merged groups, pass `agg_attractors` to
+[`stability_quantifiers_along_continuation`](@ref) (wrapping it and the parameter in length-1
 vectors if you have a single parameter).
 """
 function aggregate_attractors(attractors::Dict, featurizer, group_config)

--- a/src/continuation/continuation_stability_quantifiers.jl
+++ b/src/continuation/continuation_stability_quantifiers.jl
@@ -1,9 +1,9 @@
-export stability_measures_along_continuation
+export stability_quantifiers_along_continuation
 
 # This function is practically identical with the original one in
 # `continuation_ascm_generic.jl`; only small differences exist
 function global_continuation(
-        ascm::AttractorSeedContinueMatch{<:StabilityMeasuresAccumulator}, pcurve, ics;
+        ascm::AttractorSeedContinueMatch{<:StabilityQuantifiersAccumulator}, pcurve, ics;
         samples_per_parameter = 100, show_progress = true,
     )
     N = samples_per_parameter
@@ -16,7 +16,7 @@ function global_continuation(
     additional_ics = typeof(current_state(referenced_dynamical_system(mapper)))[]
     attractors_cont = Dict[]
     # difference one: this isn't fractions
-    measures_cont = []
+    quantifiers_cont = []
     for (i, p) in enumerate(pcurve)
         set_parameters!(referenced_dynamical_system(mapper), p)
         reset_mapper!(mapper)
@@ -34,10 +34,10 @@ function global_continuation(
         # difference two: we don't care about the return of basins_fractions
         # as initial condition mapping is accumulated anyways
         basins_fractions(mapper, pics; N, additional_ics, show_progress, offset = 2)
-        measures = finalize_accumulator(mapper)
+        quantifiers = finalize_accumulator(mapper)
         prev_attractors = deepcopy(extract_attractors(mapper))
         push!(attractors_cont, prev_attractors)
-        push!(measures_cont, measures)
+        push!(quantifiers_cont, quantifiers)
         showvalues = i < length(pcurve) ? [("pcurve index", i + 1)] : []
         ProgressMeter.next!(progress; showvalues)
     end
@@ -45,27 +45,27 @@ function global_continuation(
     rmaps = match_sequentially!(
         attractors_cont, ascm.matcher; pcurve, ds = referenced_dynamical_system(mapper)
     )
-    # and difference four, a bit more involved matching for measures:
-    transposed = accumulator_continuation_output(measures_cont, rmaps)
+    # and difference four, a bit more involved matching for quantifiers:
+    transposed = accumulator_continuation_output(quantifiers_cont, rmaps)
     return transposed, attractors_cont
 end
 
-function accumulator_continuation_output(measures_cont, rmaps)
+function accumulator_continuation_output(quantifiers_cont, rmaps)
     # match
     for (i, rmap) in enumerate(rmaps)
-        for dict in values(measures_cont[i + 1])
+        for dict in values(quantifiers_cont[i + 1])
             swap_dict_keys!(dict, rmap)
         end
     end
     # "transpose" (i.e., swap nesting order)
     transposed = Dict{String, Vector{Dict{Int64, Any}}}()
-    for measure in measures_cont[1]
-        measure_name = measure[1]
-        transposed[measure_name] = Vector{Dict{Int64, Any}}()
+    for quantifier in quantifiers_cont[1]
+        quantifier_name = quantifier[1]
+        transposed[quantifier_name] = Vector{Dict{Int64, Any}}()
     end
-    for measures in measures_cont
-        for (measure_name, measure_dict) in measures
-            push!(transposed[measure_name], measure_dict)
+    for quantifiers in quantifiers_cont
+        for (quantifier_name, quantifier_dict) in quantifiers
+            push!(transposed[quantifier_name], quantifier_dict)
         end
     end
     return transposed
@@ -75,23 +75,23 @@ end
 # make sure to allow the possiblity that the proximity options can also be
 # vectors of same length as `pcurve`; Same for the distributions
 """
-    stability_measures_along_continuation(
+    stability_quantifiers_along_continuation(
         ds::DynamicalSystem, attractors_cont, pcurve, ics;
         kw...
     )
 
-Perform a global continuation of all stability measures estimated by
-[`StabilityMeasuresAccumulator`](@ref) using the found attractors of
+Perform a global continuation of all stability quantifiers estimated by
+[`StabilityQuantifiersAccumulator`](@ref) using the found attractors of
 a previous call to [`global_continuation`](@ref) using the `ds`.
 
 This method is special because it always creates an [`BasinMapProximity`](@ref)
 mapper for the attractors at a given point along the global continuation,
-and then estimates the stability measures using [`StabilityMeasuresAccumulator`](@ref)
+and then estimates the stability quantifiers using [`StabilityQuantifiersAccumulator`](@ref)
 and the proximity mapper.
 
 There are two reasons to use this method:
 
-1. You are interested in measures related to the convergence time, which is defined
+1. You are interested in quantifiers related to the convergence time, which is defined
    more rirogously and is estimated more accurately for a proximity mapper.
 2. You want more control over the values of `ε, finite_time, weighting_distribution`,
    all of which are allowed to be `Vector`s with the same length as `pcurve`.
@@ -101,20 +101,20 @@ There are two reasons to use this method:
 
 - `ε = nothing`: given to [`BasinMapProximity`](@ref).
 - `proximity_mapper_options = NamedTuple()`: extra keywords for `BasinMapProximity`.
-- `distance, finite_time, weighting_distribution`: given to [`StabilityMeasuresAccumulator`](@ref).
-- `samples_per_parameter = 1000`: how many samples to use when estimating stability measures
-  via [`StabilityMeasuresAccumulator`](@ref). Ignored when `ics` is not a function.
+- `distance, finite_time, weighting_distribution`: given to [`StabilityQuantifiersAccumulator`](@ref).
+- `samples_per_parameter = 1000`: how many samples to use when estimating stability quantifiers
+  via [`StabilityQuantifiersAccumulator`](@ref). Ignored when `ics` is not a function.
 
 ## Aggregating attractors
 
-This function computes stability measures for whatever attractors it is given. To obtain
-measures for *aggregated* groups of attractors, first merge them with
+This function computes stability quantifiers for whatever attractors it is given. To obtain
+quantifiers for *aggregated* groups of attractors, first merge them with
 [`aggregate_continuation`](@ref) and pass the resulting `agg_attractors_cont` here:
-each merged group is then treated as a single attractor, so all measures (including those
+each merged group is then treated as a single attractor, so all quantifiers (including those
 that need the raw basin data, like medians and critical shock magnitudes) are computed
 correctly for the group, with IDs that stay consistent along the parameter axis.
 """
-function stability_measures_along_continuation(
+function stability_quantifiers_along_continuation(
         ds::DynamicalSystem,
         attractors_cont,
         pcurve,
@@ -131,14 +131,14 @@ function stability_measures_along_continuation(
         length(pcurve); desc = "Continuing accumulator quantifiers:", enabled = show_progress
     )
     N = samples_per_parameter
-    measures_cont = []
-    measure_names = nothing
+    quantifiers_cont = []
+    quantifier_names = nothing
     for (i, p) in enumerate(pcurve)
         set_parameters!(ds, p)
         attractors = attractors_cont[i]
 
         if isempty(attractors)
-            push!(measures_cont, Dict{String, Dict{Int64, Float64}}())
+            push!(quantifiers_cont, Dict{String, Dict{Int64, Float64}}())
             ProgressMeter.next!(progress)
             continue
         end
@@ -172,7 +172,7 @@ function stability_measures_along_continuation(
             d = distance
         end
 
-        accumulator = StabilityMeasuresAccumulator(
+        accumulator = StabilityQuantifiersAccumulator(
             BasinMapProximity(ds, attractors; ε = ε_, proximity_mapper_options...);
             weighting_distribution = wd, finite_time = ft,
             distance = d
@@ -184,25 +184,25 @@ function stability_measures_along_continuation(
             pics = ics
         end
         basins_fractions(accumulator, pics; N, show_progress = false)
-        measures = finalize_accumulator(accumulator)
-        if measure_names === nothing
-            measure_names = collect(keys(measures))
+        quantifiers = finalize_accumulator(accumulator)
+        if quantifier_names === nothing
+            quantifier_names = collect(keys(quantifiers))
         end
-        push!(measures_cont, measures)
+        push!(quantifiers_cont, quantifiers)
         ProgressMeter.next!(progress)
     end
 
-    # change the measures format to the expected output
+    # change the quantifiers format to the expected output
     transposed = Dict{String, Vector{Dict{Int64, Float64}}}()
-    if measure_names === nothing
+    if quantifier_names === nothing
         return transposed
     end
-    for measure_name in measure_names
-        transposed[measure_name] = Vector{Dict{Int64, Float64}}()
+    for quantifier_name in quantifier_names
+        transposed[quantifier_name] = Vector{Dict{Int64, Float64}}()
     end
-    for measures in measures_cont
-        for measure_name in measure_names
-            push!(transposed[measure_name], get(measures, measure_name, Dict{Int64, Float64}()))
+    for quantifiers in quantifiers_cont
+        for quantifier_name in quantifier_names
+            push!(transposed[quantifier_name], get(quantifiers, quantifier_name, Dict{Int64, Float64}()))
         end
     end
     return transposed

--- a/src/continuation/global_continuation_api.jl
+++ b/src/continuation/global_continuation_api.jl
@@ -1,4 +1,4 @@
-export global_continuation, GlobalContinuationAlgorithm, continuation_series, stability_measures_along_continuation
+export global_continuation, GlobalContinuationAlgorithm, continuation_series, stability_quantifiers_along_continuation
 export PerParameterInitialConditions
 
 """
@@ -39,9 +39,9 @@ Return:
 1. `fractions_cont::Vector{Dict{Int, Float64}}`. The fractions of basins of attraction.
    `fractions_cont[i]` is a dictionary mapping attractor IDs to their basin fraction
    at the `i`-th parameter combination.
-   -  This output is different if you are using [`StabilityMeasuresAccumulator`](@ref)
+   -  This output is different if you are using [`StabilityQuantifiersAccumulator`](@ref)
       in combination with [`AttractorSeedContinueMatch`](@ref). See the docstring
-      of [`StabilityMeasuresAccumulator`](@ref) for more details.
+      of [`StabilityQuantifiersAccumulator`](@ref) for more details.
 2. `attractors_cont::Vector{Dict{Int, <:Any}}`. The continued attractors.
    `attractors_cont[i]` is a dictionary mapping attractor ID to the
    attractor set at the `i`-th parameter combination.
@@ -123,4 +123,4 @@ include("continuation_ascm_generic.jl")
 include("continuation_recurrences.jl")
 include("continuation_grouping.jl")
 include("aggregate_continuation.jl")
-include("continuation_stability_measures.jl")
+include("continuation_stability_quantifiers.jl")

--- a/src/mapping/attractor_mapping.jl
+++ b/src/mapping/attractor_mapping.jl
@@ -16,7 +16,7 @@ export BasinMap,
     subdivision_based_grid,
     SubdivisionBasedGrid,
     reset_mapper!,
-    StabilityMeasuresAccumulator,
+    StabilityQuantifiersAccumulator,
     finalize_accumulator
 
 ValidICS = Union{AbstractVector, Function}
@@ -53,8 +53,8 @@ The mappers that can do this are:
 * [`BasinMapFeaturizeGroup`](@ref) with the [`GroupViaHistogram`](@ref)
   or [`GroupViaNearestFeature`](@ref) configurations.
 
-See also [`StabilityMeasuresAccumulator`](@ref) that extends this interface
-to accelerate estimation of stability measures.
+See also [`StabilityQuantifiersAccumulator`](@ref) that extends this interface
+to accelerate estimation of stability quantifiers.
 
 ## For developers
 

--- a/src/nonlocal/nonlocal.jl
+++ b/src/nonlocal/nonlocal.jl
@@ -1,4 +1,4 @@
 include("mfs.jl")
-include("stability_measures_accumulator.jl")
+include("stability_quantifiers_accumulator.jl")
 include("tipping_probabilities.jl")
 include("intermingledness.jl")

--- a/src/nonlocal/stability_quantifiers_accumulator.jl
+++ b/src/nonlocal/stability_quantifiers_accumulator.jl
@@ -8,45 +8,45 @@ struct EverywhereUniform end
 Distributions.pdf(::EverywhereUniform, u) = one(eltype(u))
 
 """
-    StabilityMeasuresAccumulator(mapper::BasinMap [, extras]; kwargs...)
+    StabilityQuantifiersAccumulator(mapper::BasinMap [, extras]; kwargs...)
 
 A special data structure that allows mapping initial conditions to attractors
-while _at the same time_ calculating many stability measures in the most efficient
+while _at the same time_ calculating many stability quantifiers in the most efficient
 way possible. `mapper` is any instance of an [`BasinMap`](@ref),
 although for [`BasinMapFeaturizeGroup`](@ref) the convergence times won't make sense.
 
-The accummulator records several measures of stability (or resilience) defined
+The accummulator records several quantifiers of stability (or resilience) defined
 in [Morr2026](@cite), and a few more related and derived shortly after,
 including the intermingledness of basins of attraction [Datseris2026Intermingled](@cite), see list below.
 However, it also allows computing any additional user-defined quantifier that is
 a function of the attractors and/or their basins of attraction via the `extras`
 argument, see the Extra quantifiers section below.
 
-`StabilityMeasuresAccumulator` can be used as any `BasinMap` with library functions
+`StabilityQuantifiersAccumulator` can be used as any `BasinMap` with library functions
 such as [`basins_fractions`](@ref). After mapping all initial conditions to attractors,
 the [`finalize_accumulator`](@ref) function should be called which will return a
-dictionary of all stability measures estimated by the accumulator,
-where each entry maps the stability measure description (`String`) to a dictionary
-mapping attractor IDs to the stability measure value.
-Calling `reset_mapper!(accumulator)` cleans up all accumulated measures.
+dictionary of all stability quantifiers estimated by the accumulator,
+where each entry maps the stability quantifier description (`String`) to a dictionary
+mapping attractor IDs to the stability quantifier value.
+Calling `reset_mapper!(accumulator)` cleans up all accumulated quantifiers.
 This functionality was developed as part of [Morr2026](@cite) and has now been extended
 to work for any `BasinMap`, current or future.
 
 **Using with [`global_continuation`](@ref)**:
-Since `StabilityMeasuresAccumulator` is formally an `BasinMap`, it can be
+Since `StabilityQuantifiersAccumulator` is formally an `BasinMap`, it can be
 used with [`global_continuation`](@ref). Simply give it as a `mapper` input
 to [`AttractorSeedContinueMatch`](@ref) and then call `global_continuation`.
 The only difference now is that `global_continuation` will not return just one
-measure of stability (the basin fraction). Rather,
+quantifier of stability (the basin fraction). Rather,
 now the first return argument of `global_continuation` will be a
-`measures_cont`, a dictionary mapping stability measures (strings)
+`quantifiers_cont`, a dictionary mapping stability quantifiers (strings)
 to vectors of dictionaries. Each vector of dictionaries is similar to `fractions_cont`
 of the typical [`global_continuation`](@ref): a vector of dictionaries mapping attractor IDs
-to the corresponding nonlocal stability measures.
+to the corresponding nonlocal stability quantifiers.
 
-Use [`stability_measures_along_continuation`](@ref) for continuation of stability  measures computed
+Use [`stability_quantifiers_along_continuation`](@ref) for continuation of stability  quantifiers computed
 on the basis of an `BasinMapProximity` mapper from already found attractors.
-This is useful to do for measures related to the convergence time, which is defined
+This is useful to do for quantifiers related to the convergence time, which is defined
 more rirogously and is estimated more accurately for a proximity mapper.
 
 ## Keyword arguments
@@ -65,29 +65,29 @@ more rirogously and is estimated more accurately for a proximity mapper.
 
 ## Description
 
-`StabilityMeasuresAccumulator` efficiently uses a single `id = mapper(u0)` call
-to accumulate information for many different stability measures corresponding
+`StabilityQuantifiersAccumulator` efficiently uses a single `id = mapper(u0)` call
+to accumulate information for many different stability quantifiers corresponding
 to each attractor of the dynamical system.
-It accumulates all these different measures when different initial conditions
+It accumulates all these different quantifiers when different initial conditions
 are mapped through it. After enough `u0`s have been given to the accumulator, they
 can be finalized (comput maxima or averages) using `finalize!(accumulator)`.
 
-You can extent this functionality by adding new stability measures as long as their
+You can extent this functionality by adding new stability quantifiers as long as their
 estimation can be done on the basis of the three quantities accumulated:
 the basin dictionary mapping initial conditions to attractors,
 the distance of each initial condition to each attractor,
 and the convergence time of each initial condition.
 
-The following stability measures are estimated for each attractor
-(and the returned dictionary maps strings with the names of the measures
-to the dictionaries containing the measure values for each attractor):
+The following stability quantifiers are estimated for each attractor
+(and the returned dictionary maps strings with the names of the quantifiers
+to the dictionaries containing the quantifier values for each attractor):
 
-### Local (fixed point) stability measures
+### Local (fixed point) stability quantifiers
 
-These measures apply only to fixed point attractors.
+These quantifiers apply only to fixed point attractors.
 Their value is `NaN` if an attractor is not a fixed point (`length(A) > 1`).
 If an unstable fixed point attractor is recorded (due to an initial condition starting
-there for example), a value `Inf` is assigned to all measures.
+there for example), a value `Inf` is assigned to all quantifiers.
 
 
 * `characteristic_return_time`: The reciprocal of the largest real part of the
@@ -103,9 +103,9 @@ there for example), a value `Inf` is assigned to all measures.
 * `maximal_amplification_time`: The time at which the maximal amplification
   occurs (continuous time). Always 0 for discrete time systems.
 
-### Nonlocal stability measures
+### Nonlocal stability quantifiers
 
-The information for these nonlocal stability measures is accumulated while initial
+The information for these nonlocal stability quantifiers is accumulated while initial
 conditions are mapped to attractors. Afterwards it is aggregated according to the
 probability density `weighting_distribution` when calling `finalize_accumulator!`.
 
@@ -187,7 +187,7 @@ end
 extras = Dict("maxv" => extra_function)
 ```
 """
-struct StabilityMeasuresAccumulator{AM <: BasinMap, V <: AbstractVector, F, M, W, E <: Dict, X} <: BasinMap
+struct StabilityQuantifiersAccumulator{AM <: BasinMap, V <: AbstractVector, F, M, W, E <: Dict, X} <: BasinMap
     mapper::AM
     u0s::Vector{V}
     bs::Vector{Int} # basins vector
@@ -199,7 +199,7 @@ struct StabilityMeasuresAccumulator{AM <: BasinMap, V <: AbstractVector, F, M, W
     idistances::X
 end
 
-function StabilityMeasuresAccumulator(
+function StabilityQuantifiersAccumulator(
         mapper::BasinMap, extras = Dict();
         finite_time = 1.0, weighting_distribution = EverywhereUniform(),
         distance = Centroid(), idistances = [Euclidean()],
@@ -211,7 +211,7 @@ function StabilityMeasuresAccumulator(
     F = typeof(finite_time)
     M = typeof(distance)
     W = typeof(weighting_distribution)
-    return StabilityMeasuresAccumulator{AM, V, F, M, W, typeof(extras), typeof(idistances)}(
+    return StabilityQuantifiersAccumulator{AM, V, F, M, W, typeof(extras), typeof(idistances)}(
         mapper,
         Vector{V}(),
         Vector{Int}(),
@@ -225,7 +225,7 @@ function StabilityMeasuresAccumulator(
 end
 
 # Extend `BasinMap` API:
-function reset_mapper!(a::StabilityMeasuresAccumulator)
+function reset_mapper!(a::StabilityQuantifiersAccumulator)
     reset_mapper!(a.mapper)
     empty!(a.u0s)
     empty!(a.bs)
@@ -233,19 +233,19 @@ function reset_mapper!(a::StabilityMeasuresAccumulator)
     return
 end
 
-function extract_attractors(accumulator::StabilityMeasuresAccumulator)
+function extract_attractors(accumulator::StabilityQuantifiersAccumulator)
     return extract_attractors(accumulator.mapper)
 end
-function referenced_dynamical_system(accumulator::StabilityMeasuresAccumulator)
+function referenced_dynamical_system(accumulator::StabilityQuantifiersAccumulator)
     return referenced_dynamical_system(accumulator.mapper)
 end
-function convergence_time(accumulator::StabilityMeasuresAccumulator)
+function convergence_time(accumulator::StabilityQuantifiersAccumulator)
     return convergence_time(accumulator.mapper)
 end
 
-allows_mapper_u0(a::StabilityMeasuresAccumulator) = allows_mapper_u0(a.mapper)
+allows_mapper_u0(a::StabilityQuantifiersAccumulator) = allows_mapper_u0(a.mapper)
 
-function (accumulator::StabilityMeasuresAccumulator)(u0)
+function (accumulator::StabilityQuantifiersAccumulator)(u0)
     id = accumulator.mapper(u0)
     push!(accumulator.u0s, u0)
     push!(accumulator.bs, id)
@@ -254,21 +254,21 @@ function (accumulator::StabilityMeasuresAccumulator)(u0)
 end
 
 """
-    finalize_accumulator(accumulator::StabilityMeasuresAccumulator)
+    finalize_accumulator(accumulator::StabilityQuantifiersAccumulator)
 
-Return a dictionary mapping stability measures (strings) to dictionaries
-mapping attractor IDs to corresponding measure values.
+Return a dictionary mapping stability quantifiers (strings) to dictionaries
+mapping attractor IDs to corresponding quantifier values.
 
 The attractors themselves are those of the `accumulator`'s mapper and can be
 obtained with `extract_attractors(accumulator)`.
 
-See [`StabilityMeasuresAccumulator`](@ref) for more.
+See [`StabilityQuantifiersAccumulator`](@ref) for more.
 
-To compute stability measures for *aggregated* groups of attractors, merge them first with
+To compute stability quantifiers for *aggregated* groups of attractors, merge them first with
 [`aggregate_continuation`](@ref) and pass the merged attractors to
-[`stability_measures_along_continuation`](@ref).
+[`stability_quantifiers_along_continuation`](@ref).
 """
-function finalize_accumulator(accumulator::StabilityMeasuresAccumulator)
+function finalize_accumulator(accumulator::StabilityQuantifiersAccumulator)
     ds = referenced_dynamical_system(accumulator)
     attractors = extract_attractors(accumulator.mapper)
     bs = accumulator.bs
@@ -388,7 +388,7 @@ function finalize_accumulator(accumulator::StabilityMeasuresAccumulator)
         minimal_critical_shock_magnitude[-1] = NaN # no critical shock for -1 attractor
     end
 
-    # linear measures
+    # linear quantifiers
     characteristic_return_time = Dict(id => NaN for id in ids)
     reactivity = Dict(id => NaN for id in ids)
     maximal_amplification = Dict(id => NaN for id in ids)
@@ -508,7 +508,7 @@ function weighted_median(
 end
 
 # Extension function to allow accumulator to work also with non-single-u0 mappers
-function basins_fractions_grouped(accumulator::StabilityMeasuresAccumulator, ics, progress::Progress, labels)
+function basins_fractions_grouped(accumulator::StabilityQuantifiersAccumulator, ics, progress::Progress, labels)
     # note that ics is always collected into vector, cascaded by `basins_fraction`.
     # Here we'll call the same function with the stored mapper, cheating the system
     fs, _labels = basins_fractions(accumulator.mapper, ics; show_progress = progress.core.enabled)

--- a/test/nonlocal/intermingledness.jl
+++ b/test/nonlocal/intermingledness.jl
@@ -64,11 +64,11 @@ end
         Euclidean(),
         WeightedEuclidean([0, 1]), # distance of x dimension only
     ]
-    accumulator = StabilityMeasuresAccumulator(mapper; idistances = distances)
+    accumulator = StabilityQuantifiersAccumulator(mapper; idistances = distances)
 
     A = ics_from_grid(grid)
     for u0 in A
-        id = accumulator(u0) # run this to accumulate measures
+        id = accumulator(u0) # run this to accumulate quantifiers
     end
     results = finalize_accumulator(accumulator)
 

--- a/test/nonlocal/stability_quantifiers_accumulator.jl
+++ b/test/nonlocal/stability_quantifiers_accumulator.jl
@@ -17,8 +17,8 @@ using Random
             end
         end
     end
-    # Test the computation of nonlocal stability measures using the
-    # `StabilityMeasuresAccumulator` for a dumb map.
+    # Test the computation of nonlocal stability quantifiers using the
+    # `StabilityQuantifiersAccumulator` for a dumb map.
     dynamics = DiscreteDynamicalSystem(dumb_map, [1.0, 1.0], [1.0])
     grid = ([-1, 0, 1.0], [-1, 0, 1.0])
     mapper = BasinMapRecurrences(dynamics, grid; sparse = false)
@@ -31,10 +31,10 @@ using Random
         end
         attractors = extract_attractors(mapper)
         mapper = BasinMapProximity(dynamics, attractors, 0.01, Ttr = 0)
-        accumulator = StabilityMeasuresAccumulator(mapper, finite_time = 0.5)
+        accumulator = StabilityQuantifiersAccumulator(mapper, finite_time = 0.5)
 
         for u0 in A
-            id = accumulator(u0) # run this to accumulate measures
+            id = accumulator(u0) # run this to accumulate quantifiers
         end
 
         results = finalize_accumulator(accumulator)
@@ -76,7 +76,7 @@ using Random
     end
 
     @testset "continuation" begin
-        # Now we test the continuation of nonlocal stability measures.
+        # Now we test the continuation of nonlocal stability quantifiers.
         pcurve = [[1 => p] for p in [-1.0, 1.0]]
         attractors_cont = [
             Dict(1 => StateSpaceSet([SVector(0.0, 0.0)])),
@@ -86,12 +86,12 @@ using Random
         proximity_mapper_options = (
             Ttr = 0, stop_at_Δt = false, horizon_limit = 1.0e2, consecutive_lost_steps = 10000,
         )
-        measures_cont = stability_measures_along_continuation(
+        quantifiers_cont = stability_quantifiers_along_continuation(
             dynamics, attractors_cont, pcurve, ics_from_grid(grid), ε = 0.1, finite_time = 0.5,
             proximity_mapper_options = proximity_mapper_options
         )
 
-        measures_cont_expected = Dict(
+        quantifiers_cont_expected = Dict(
             "finite_time_basin_stability" => [Dict(1 => 0.11111), Dict(2 => 0.11111, 1 => 0.11111)],
             "maximal_noncritical_shock_magnitude" => [Dict(1 => 1.41421), Dict(2 => 2.23607, 1 => 2.0)],
             "median_convergence_pace" => [Dict(1 => 0.70711), Dict(2 => 0.5, 1 => 0.5)],
@@ -110,12 +110,12 @@ using Random
             "maximal_amplification_time" => [Dict(1 => 0.0), Dict(2 => 0.0, 1 => 0.0)]
         )
         # Validate the results
-        for (key, value) in measures_cont_expected
-            @test key in keys(measures_cont)
+        for (key, value) in quantifiers_cont_expected
+            @test key in keys(quantifiers_cont)
             for k in [1, 2]
                 @test isapprox(
                     sort(collect(values(value[k]))),
-                    sort(collect(values(measures_cont[key][k]))),
+                    sort(collect(values(quantifiers_cont[key][k]))),
                     atol = 1.0e-5,
                     nans = true,
                 )
@@ -135,7 +135,7 @@ using Random
         )
 
         # Merge all attractors at every step via a large threshold on the x-coordinate, then
-        # compute the stability measures on the merged attractors.
+        # compute the stability quantifiers on the merged attractors.
         featurizer = A -> SVector(first(A)[1])
         merge_config = GroupViaPairwiseComparison(threshold = 3.0, rescale_features = false)
         agg_attractors_cont, centroids_cont, members_cont = aggregate_continuation(
@@ -162,26 +162,26 @@ using Random
         @test sort(mem_step[only(keys(mem_step))]) == [1, 2]
         @test cent_step[only(keys(cent_step))] ≈ SVector(0.0)
 
-        measures_agg = stability_measures_along_continuation(
+        quantifiers_agg = stability_quantifiers_along_continuation(
             dynamics, agg_attractors_cont, pcurve, ics_from_grid(grid);
             ε = 0.1, finite_time = 0.5, proximity_mapper_options,
         )
 
         # At both steps all ICs belong to the merged attractor → basin fraction == 1
-        merged_id_1 = first(k for k in keys(measures_agg["basin_fraction"][1]) if k != -1)
-        merged_id_2 = first(k for k in keys(measures_agg["basin_fraction"][2]) if k != -1)
-        @test measures_agg["basin_fraction"][1][merged_id_1] ≈ 1.0
-        @test measures_agg["basin_fraction"][2][merged_id_2] ≈ 1.0
+        merged_id_1 = first(k for k in keys(quantifiers_agg["basin_fraction"][1]) if k != -1)
+        merged_id_2 = first(k for k in keys(quantifiers_agg["basin_fraction"][2]) if k != -1)
+        @test quantifiers_agg["basin_fraction"][1][merged_id_1] ≈ 1.0
+        @test quantifiers_agg["basin_fraction"][2][merged_id_2] ≈ 1.0
         # With only one aggregated group, no critical shock at either step
-        @test measures_agg["minimal_critical_shock_magnitude"][1][merged_id_1] == Inf
-        @test measures_agg["minimal_critical_shock_magnitude"][2][merged_id_2] == Inf
+        @test quantifiers_agg["minimal_critical_shock_magnitude"][1][merged_id_1] == Inf
+        @test quantifiers_agg["minimal_critical_shock_magnitude"][2][merged_id_2] == Inf
     end
 end
 
 
 @testset "fixed point continuous" begin
 
-    # Now we will test the local stability measures in `StabilityMeasuresAccumulator` in a
+    # Now we will test the local stability quantifiers in `StabilityQuantifiersAccumulator` in a
     # linear system.
     function linear_evolution(z, p, n)
         if p[1] < 0.0
@@ -196,8 +196,8 @@ end
     grid = ([-1.0, -0.1, 0.3, 1.0], [-1.0, -0.3, 0.1, 1.0])
     mapper = BasinMapRecurrences(dynamics, grid; sparse = false)
 
-    # Use the StabilityMeasuresAccumulator to compute measures
-    accumulator = StabilityMeasuresAccumulator(mapper, finite_time = 0.5)
+    # Use the StabilityQuantifiersAccumulator to compute quantifiers
+    accumulator = StabilityQuantifiersAccumulator(mapper, finite_time = 0.5)
     A = ics_from_grid(grid)
     for u0 in A
         id = accumulator(u0)
@@ -234,24 +234,24 @@ end
         proximity_mapper_options_local = (
             Ttr = 0, stop_at_Δt = false, horizon_limit = 1.0e2, consecutive_lost_steps = 10000,
         )
-        measures_cont_local = stability_measures_along_continuation(
+        quantifiers_cont_local = stability_quantifiers_along_continuation(
             dynamics, attractors_cont_local, pcurve_local, ics_from_grid(grid), ε = 0.1, finite_time = 0.5,
             proximity_mapper_options = proximity_mapper_options_local
         )
 
-        measures_cont_local_expected = Dict(
+        quantifiers_cont_local_expected = Dict(
             "characteristic_return_time" => [Dict(-1 => NaN, 1 => Inf), Dict(1 => 2.0)],
             "reactivity" => [Dict(-1 => NaN, 1 => Inf), Dict(1 => -0.5)],
             "maximal_amplification" => [Dict(-1 => NaN, 1 => Inf), Dict(1 => 1.0)],
             "maximal_amplification_time" => [Dict(-1 => NaN, 1 => Inf), Dict(1 => 0.0)]
         )
 
-        for (key, value) in measures_cont_local_expected
-            @test key in keys(measures_cont_local)
+        for (key, value) in quantifiers_cont_local_expected
+            @test key in keys(quantifiers_cont_local)
             for k in [1, 2]
                 @test isapprox(
                     sort(collect(values(value[k]))),
-                    sort(collect(values(measures_cont_local[key][k]))),
+                    sort(collect(values(quantifiers_cont_local[key][k]))),
                     atol = 1.0e-5,
                     nans = true,
                 )
@@ -263,7 +263,7 @@ end
 
 @testset "Discrete time" begin
     # For these parameters the map has 1 fixed point and one period 3 orbit.
-    # The tests failed because linear measures are not computed for discrete sytems now.
+    # The tests failed because linear quantifiers are not computed for discrete sytems now.
     henon_rule_alter(x, p, n) = SVector{2}(1.0 - p[1] * x[1]^2 + x[2], -p[2] * x[1])
     μ = 1.05; J = 0.9
     ds = DeterministicIteratedMap(henon_rule_alter, zeros(2), [μ, J])
@@ -272,19 +272,19 @@ end
     grid = (xg, yg)
 
     mapper = BasinMapRecurrences(ds, grid; sparse = false, consecutive_recurrences = 1000)
-    accumulator = StabilityMeasuresAccumulator(mapper)
+    accumulator = StabilityQuantifiersAccumulator(mapper)
 
     A = ics_from_grid(grid)
     for u0 in A
         id = accumulator(u0)
     end
-    stability_measures = finalize_accumulator(accumulator)
+    stability_quantifiers = finalize_accumulator(accumulator)
 
-    measures = ["basin_stability", "minimal_critical_shock_magnitude"]
+    quantifiers = ["basin_stability", "minimal_critical_shock_magnitude"]
 
-    @testset "Henon $m" for m in measures
-        measures = collect(values(stability_measures[m]))
-        @test count(!isnan, measures) ≥ 0
+    @testset "Henon $m" for m in quantifiers
+        quantifiers = collect(values(stability_quantifiers[m]))
+        @test count(!isnan, quantifiers) ≥ 0
     end
 end
 
@@ -330,10 +330,10 @@ end
     extras = Dict(
         "extra" => extra_function
     )
-    accumulator = StabilityMeasuresAccumulator(mapper, extras)
+    accumulator = StabilityQuantifiersAccumulator(mapper, extras)
 
     for u0 in A
-        id = accumulator(u0) # run this to accumulate measures
+        id = accumulator(u0) # run this to accumulate quantifiers
     end
 
     results = finalize_accumulator(accumulator)
@@ -347,8 +347,8 @@ end
     @testset "continuation" begin
         rs = [0.5, 1.0]
         gca = AttractorSeedContinueMatch(accumulator)
-        measures_cont, attractors_cont = global_continuation(gca, rs, 1, A)
-        @test measures_cont["extra"] == [Dict(1 => 0, 2 => 3), Dict(1 => 0, 2 => 0)]
+        quantifiers_cont, attractors_cont = global_continuation(gca, rs, 1, A)
+        @test quantifiers_cont["extra"] == [Dict(1 => 0, 2 => 3), Dict(1 => 0, 2 => 0)]
     end
 end
 
@@ -374,22 +374,22 @@ end
     featurizer(A, t) = A[end]
     gconfig = GroupViaPairwiseComparison()
     mapper = BasinMapFeaturizeGroup(dynamics, featurizer, gconfig)
-    accumulator = StabilityMeasuresAccumulator(mapper)
+    accumulator = StabilityQuantifiersAccumulator(mapper)
 
     @testset "single parameter" begin
         fs, labels = basins_fractions(accumulator, ics)
         @test all(sort!(collect(values(fs))) .≈ [0.333333333333333333, 0.6666666666666])
-        measures = finalize_accumulator(accumulator)
-        @test isequal(measures["minimal_critical_shock_magnitude"], Dict(2 => 2.0, 1 => 1.0))
+        quantifiers = finalize_accumulator(accumulator)
+        @test isequal(quantifiers["minimal_critical_shock_magnitude"], Dict(2 => 2.0, 1 => 1.0))
     end
 
     @testset "continuation" begin
         pcurve = [[1 => r] for r in rs]
         acsm = AttractorSeedContinueMatch(accumulator)
-        measures_cont, attractors_cont = global_continuation(acsm, pcurve, ics)
+        quantifiers_cont, attractors_cont = global_continuation(acsm, pcurve, ics)
 
-        @test isequal(measures_cont["minimal_critical_shock_magnitude"][2], Dict(2 => 2.0, 1 => 1.0))
-        fs = measures_cont["basin_fraction"][1]
+        @test isequal(quantifiers_cont["minimal_critical_shock_magnitude"][2], Dict(2 => 2.0, 1 => 1.0))
+        fs = quantifiers_cont["basin_fraction"][1]
         @test all(sort!(collect(v for (k, v) in fs if k != -1)) .≈ [0.333333333333333333, 0.6666666666666])
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,7 +38,7 @@ end
 
     @testset "nonlocal stab" begin
         testfile("nonlocal/mfstest.jl")
-        testfile("nonlocal/stability_measures_accumulator.jl")
+        testfile("nonlocal/stability_quantifiers_accumulator.jl")
     end
 
     @testset "boundaries" begin


### PR DESCRIPTION
Renames the stability *measures* terminology to *quantifiers* throughout the codebase: the `StabilityMeasuresAccumulator` type, the `stability_measures_along_continuation` function, the corresponding source/test files, and all related docstrings and docs. Non-stability uses of "measure" (e.g. `ComplexityMeasures`, measure-theoretic terms) are left untouched.