### PR TITLE
Introduce sampler interface for `global_continuation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,6 @@ This release accompanies the release of our paper "Global continuation as a comp
   structured around a new abstract type `InitialConditionSampler`.
   - Concrete types include `RandomICSampler, PrescribedICs, PerParameterICs` and more
     to come in the future.
-  - **DEPRECATED**: Passing a vector of initial conditions or a sampling function to
-    `global_continuation` is now deprecated. Use the aforementioned types.
 
 ## Breaking changes and Deprecations
 
@@ -30,6 +28,8 @@ This release accompanies the release of our paper "Global continuation as a comp
 - **DEPRECATED**: giving a vector of initial conditions, or a sampling function,
   as the last argument to `global_continuation` is deprecated. Use an instance of a subtype
   of `InitialConditionSampler` instead.
+- **DEPRECATED**: Passing a vector of initial conditions or a sampling function to
+  `global_continuation` is now deprecated. Use the `InitialConditionSampler` interface.
 
 ### Renaming of stability measures
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ This release accompanies the release of our paper "Global continuation as a comp
   structured around a new abstract type `InitialConditionSampler`.
   - Concrete types include `RandomICSampler, PrescribedICs, PerParameterICs` and more
     to come in the future.
+  - **DEPRECATED**: Passing a vector of initial conditions or a sampling function to
+    `global_continuation` is now deprecated. Use the aforementioned types.
 
 ## Breaking changes and Deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,10 @@ This release accompanies the release of our paper "Global continuation as a comp
   - Concrete types include `RandomICSampler, PrescribedICs, PerParameterICs` and more
     to come in the future.
 
-## Deprecations
+## Breaking changes and Deprecations
 
+- **BREAKING**: The `basins_fractions` output structure has been reworked. Now `basins_fractions` always returns only one output regardless of inputs: the fractions.
+  A new function `basins_fractions_labels` returns also the labels.
 - **BREAKING**: All deprecations existing before v2 release have been removed. Add v1.39 explicitly to resolve this if need be.
 - **DEPRECATED**: calling `global_continuation` with `prange, pidx` is deprecated.
   Use the version where a single `pcurve` is provided instead, by making
@@ -27,14 +29,14 @@ This release accompanies the release of our paper "Global continuation as a comp
   as the last argument to `global_continuation` is deprecated. Use an instance of a subtype
   of `InitialConditionSampler` instead.
 
-## Renaming of stability measures
+### Renaming of stability measures
 
 - The concept of "stability measures" has been renamed into "stability quantifiers" throughout the docs
 - The following renames of API are deprecated:
   - `stability_measures_along_continuation` -> `stability_quantifiers_along_continuation`
   - `StabilityMeasuresAccumulator` -> `StabilityQuantifiersAccumulator`
 
-## Renaming of attractor mappers
+### Renaming of attractor mappers
 
 The `AttractorMapper` constructions have been fully renamed. All following renames are deprecated:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This release accompanies the release of our paper "Global continuation as a comp
   additional quantities after sampling the state space.
 - `continuation_series` now allows for mixed type outputs, so that the fill value
   can be of different type (e.g., `missing`) than the continuation quantity.
+- New API for instructing `global_continuation` on how to sample initial conditions
+  structured around a new abstract type `InitialConditionSampler`.
+  - Concrete types include `RandomICSampler, PrescribedICs, PerParameterICs` and more
+    to come in the future.
 
 ## Deprecations
 
@@ -16,6 +20,9 @@ This release accompanies the release of our paper "Global continuation as a comp
 - **DEPRECATED**: calling `global_continuation` with `prange, pidx` is deprecated.
   Use the version where a single `pcurve` is provided instead, by making
   `pcurve = [Dict(pidx => p) for p in prange]`.
+- **DEPRECATED**: giving a vector of initial conditions, or a sampling function,
+  as the last argument to `global_continuation` is deprecated. Use an instance of a subtype
+  of `InitialConditionSampler` instead.
 
 ## Renaming of stability measures
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,12 @@ This release accompanies the release of our paper "Global continuation as a comp
 
 - New function `hilbert_pcurve`. It conveniently uses Hilbert curves to create a parameter curve efficiently spanning a multidimensional space. To be used with `global_continuation`.
 
-## Prior deprecations removed
+## Deprecations
 
 - **BREAKING**: All deprecations existing before v2 release have been removed. Add v1.39 explicitly to resolve this if need be.
+- **DEPRECATED**: calling `global_continuation` with `prange, pidx` is deprecated.
+  Use the version where a single `pcurve` is provided instead, by making
+  `pcurve = [Dict(pidx => p) for p in prange]`.
 
 ## Renaming of stability measures
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -86,6 +86,7 @@ Calculating basins of attraction, or their state space fractions, can be done wi
 
 ```@docs
 basins_fractions
+basins_fractions_labels
 basins_of_attraction
 statespace_sampler
 ```

--- a/src/basins/basins_utilities.jl
+++ b/src/basins/basins_utilities.jl
@@ -31,7 +31,7 @@ See also [`convergence_and_basins_of_attraction`](@ref).
 function basins_of_attraction(bmap::BasinMap, grid::Tuple; kwargs...)
     basins = zeros(Int32, map(length, grid))
     A = ics_from_grid(grid)
-    fs, labels = basins_fractions(bmap, A; kwargs...)
+    _, labels = basins_fractions_labels(bmap, A; kwargs...)
     attractors = extract_attractors(bmap)
     vec(basins) .= vec(labels)
     return ArrayBasinsOfAttraction(basins, attractors, grid)
@@ -48,16 +48,14 @@ along with (perhaps approximated) found attractors contained within a
 The initial conditions `ics`, and the keyword arguments `kwargs` are the same
 as in [`basins_fractions`](@ref) with the same function signature. This function
 is a small convenience wrapper which uses the sampled initial conditions and their
-corresponding labels, from `basins_fractions`, to construct a [`SampledBasinsOfAttraction`](@ref)
+corresponding labels to construct a [`SampledBasinsOfAttraction`](@ref)
 
 Note that, as with the other `basins_of_attraction` function, the return can be decomposed:
 `basins, attractors = boa`.
-
 """
-function basins_of_attraction(bmap::BasinMap, ics::ValidICS; show_progress = true, N = 1000)
-    used_container = ics isa AbstractVector
-    ics_vec = used_container ? ics : [ics() for _ in 1:N]
-    _, labels = basins_fractions(bmap, ics_vec, show_progress = show_progress)
+function basins_of_attraction(bmap::BasinMap, ics; show_progress = true, N = 1000)
+    ics_vec = ics isa AbstractVector ? ics : [copy(ics()) for _ in 1:N]
+    _, labels = basins_fractions_labels(bmap, ics_vec, show_progress = show_progress)
     attractors = extract_attractors(bmap)
     return SampledBasinsOfAttraction(labels, attractors, ics_vec)
 end
@@ -170,7 +168,7 @@ See also [`convergence_time`](@ref).
 - `show_progress = true`: show progress bar.
 """
 function convergence_and_basins_fractions(
-        bmap::BasinMap, ics::ValidICS;
+        bmap::BasinMap, ics;
         show_progress = true, N = 1000,
     )
     N = ics isa Function ? N : length(ics)

--- a/src/basins/fractality_of_basins.jl
+++ b/src/basins/fractality_of_basins.jl
@@ -127,16 +127,6 @@ function basin_entropy(points::AbstractVector, ids::AbstractVector{<:Integer}, n
             found == nneigh && break
         end
 
-        # Fallback: in degenerate cases where self wasn't returned by knn query,
-        # fill remaining slots directly from the returned nearest-neighbor indices.
-        if found < nneigh
-            for j in eachindex(idxs)
-                found += 1
-                local_idxs[found] = idxs[j]
-                found == nneigh && break
-            end
-        end
-
         neighbor_ids = @view ids[local_idxs]
         uvals = unique(neighbor_ids)
         if length(uvals) > 1

--- a/src/continuation/continuation_ascm_generic.jl
+++ b/src/continuation/continuation_ascm_generic.jl
@@ -104,11 +104,11 @@ ASCM(bmap, matcher = MatchBySSSetDistance(); seeding = _default_seeding) =
     ASCM(bmap, matcher, seeding)
 
 # TODO: This is currently not used, and not sure if it has to be.
-function _scaled_seeding(attractor::AbstractStateSpaceSet; rng = MersenneTwister(1))
-    max_possible_seeds = 6
-    seeds = round(Int, log(max_possible_seeds, length(attractor)))
+function _scaled_seeding(attractor::AbstractStateSpaceSet, rng = MersenneTwister(1))
+    max_possible_seeds = 9 # ≈ log(10,000)
+    seeds = round(Int, log(length(attractor)))
     seeds = clamp(seeds, 1, max_possible_seeds)
-    return (rand(rng, vec(attractor)) for _ in 1:seeds)
+    return (rand(rng, attractor) for _ in 1:seeds)
 end
 
 # This is the one used

--- a/src/continuation/continuation_ascm_generic.jl
+++ b/src/continuation/continuation_ascm_generic.jl
@@ -117,7 +117,7 @@ function _default_seeding(attractor::AbstractStateSpaceSet)
 end
 
 function global_continuation(
-        ascm::AttractorSeedContinueMatch, pcurve, icsampler;
+        ascm::AttractorSeedContinueMatch, pcurve::Vector, icsampler::InitialConditionSampler;
         samples_per_parameter = 100, show_progress = true,
     )
     N = samples_per_parameter

--- a/src/continuation/continuation_ascm_generic.jl
+++ b/src/continuation/continuation_ascm_generic.jl
@@ -117,7 +117,7 @@ function _default_seeding(attractor::AbstractStateSpaceSet)
 end
 
 function global_continuation(
-        ascm::AttractorSeedContinueMatch, pcurve, ics;
+        ascm::AttractorSeedContinueMatch, pcurve, icsampler;
         samples_per_parameter = 100, show_progress = true,
     )
     N = samples_per_parameter
@@ -154,6 +154,8 @@ function global_continuation(
         else
             pics = ics
         end
+        TODO: okay this complicates things a bit because you also need the basin fractions update?
+        pics = generate_ics(icsampler, p)
         # and finally call basin fractions; it knows how to do all calculations given the bmap
         ret = basins_fractions(bmap, pics; N, additional_ics, show_progress, offset = 2)
         fs = pics isa AbstractVector ? ret[1] : ret # if fractions also return labels.

--- a/src/continuation/continuation_ascm_generic.jl
+++ b/src/continuation/continuation_ascm_generic.jl
@@ -154,12 +154,24 @@ function global_continuation(
         fs = pics isa AbstractVector ? ret[1] : ret # if fractions also return labels.
         # deepcopy is important here as attractor container always referrenced
         prev_attractors = deepcopy(extract_attractors(bmap))
+        update_sampler!(sampler, what_do_we_need)
+        # Now, check if the sampler requires us to re-sample at the current parameter
+        while resampling_required(sampler)
+            # Do something something,
+            # Generate new ICs,
+            # Do more somthing, and then finally update the sampler again
+            # update the sampler type, if needed
+            update_sampler!(sampler, what_do_we_need)
+
+            # The big question is: how can we re-use the initial conditions
+            # that were already generated and run through basin fractions...?
+            # We can modify basin fractions to return the labels of the init. cond.
+            # as well if this helps.
+        end
+        # All the computations are done, and now we just store the result(s)
         # we don't match attractors here, this happens directly at the end.
-        # here we just store the result
         push!(fractions_cont, fs)
         push!(attractors_cont, prev_attractors)
-        # update the sampler type, if needed
-        update_sampler!(sampler, what_do_we_need)
         # show progress
         showvalues = i < length(pcurve) ? [("pcurve index", i + 1)] : []
         ProgressMeter.next!(progress; showvalues)

--- a/src/continuation/continuation_ascm_generic.jl
+++ b/src/continuation/continuation_ascm_generic.jl
@@ -151,12 +151,12 @@ function global_continuation(
         pics = generate_ics(icsampler, p)
         # TODO: Make basin_fractions always return labels in this function
         # and finally call basin fractions; it knows how to do all calculations given the bmap
-        fs, labels = basins_fractions(bmap, pics; N = length(icsampler), additional_ics, show_progress, offset = 2)
+        fs, labels = basins_fractions(bmap, pics; additional_ics, show_progress, offset = 2)
         update_sampler!(sampler, labels)
         # Now, check if the sampler requires us to re-sample at the current parameter
         while resampling_required(sampler)
             pics = generate_ics(icsampler, p)
-            fs, labels = basins_fractions(bmap, pics; N = length(icsampler), additional_ics, show_progress, offset = 2)
+            fs, labels = basins_fractions(bmap, pics; additional_ics, show_progress, offset = 2)
             # Do more somthing, and then finally update the sampler again
             # update the sampler type, if needed
             update_sampler!(sampler, labels)

--- a/src/continuation/continuation_ascm_generic.jl
+++ b/src/continuation/continuation_ascm_generic.jl
@@ -151,12 +151,12 @@ function global_continuation(
         pics = generate_ics(icsampler, p)
         # TODO: Make basin_fractions always return labels in this function
         # and finally call basin fractions; it knows how to do all calculations given the bmap
-        fs, labels = basins_fractions(bmap, pics; additional_ics, show_progress, offset = 2)
+        fs, labels = basins_fractions_labels(bmap, pics; additional_ics, show_progress, offset = 2)
         update_sampler!(sampler, labels)
         # Now, check if the sampler requires us to re-sample at the current parameter
         while resampling_required(sampler)
             pics = generate_ics(icsampler, p)
-            fs, labels = basins_fractions(bmap, pics; additional_ics, show_progress, offset = 2)
+            fs, labels = basins_fractions_labels(bmap, pics; additional_ics, show_progress, offset = 2)
             # Do more somthing, and then finally update the sampler again
             # update the sampler type, if needed
             update_sampler!(sampler, labels)

--- a/src/continuation/continuation_ascm_generic.jl
+++ b/src/continuation/continuation_ascm_generic.jl
@@ -148,13 +148,7 @@ function global_continuation(
                 push!(additional_ics, u0)
             end
         end
-        # now prepare the initial conditions if per-parameter is requested
-        if ics isa PerParameterInitialConditions
-            pics = ics.generator(p, N)
-        else
-            pics = ics
-        end
-        TODO: okay this complicates things a bit because you also need the basin fractions update?
+        # prepare the initial conditions
         pics = generate_ics(icsampler, p)
         # and finally call basin fractions; it knows how to do all calculations given the bmap
         ret = basins_fractions(bmap, pics; N, additional_ics, show_progress, offset = 2)

--- a/src/continuation/continuation_ascm_generic.jl
+++ b/src/continuation/continuation_ascm_generic.jl
@@ -158,6 +158,9 @@ function global_continuation(
         # here we just store the result
         push!(fractions_cont, fs)
         push!(attractors_cont, prev_attractors)
+        # update the sampler type, if needed
+        update_sampler!(sampler, what_do_we_need)
+        # show progress
         showvalues = i < length(pcurve) ? [("pcurve index", i + 1)] : []
         ProgressMeter.next!(progress; showvalues)
     end

--- a/src/continuation/continuation_ascm_generic.jl
+++ b/src/continuation/continuation_ascm_generic.jl
@@ -118,9 +118,8 @@ end
 
 function global_continuation(
         ascm::AttractorSeedContinueMatch, pcurve::Vector, icsampler::InitialConditionSampler;
-        samples_per_parameter = 100, show_progress = true,
+        show_progress = true,
     )
-    N = samples_per_parameter
     progress = ProgressMeter.Progress(
         length(pcurve);
         desc = "Global continuation:", PMKWARGS..., enabled = show_progress
@@ -151,7 +150,7 @@ function global_continuation(
         # prepare the initial conditions
         pics = generate_ics(icsampler, p)
         # and finally call basin fractions; it knows how to do all calculations given the bmap
-        ret = basins_fractions(bmap, pics; N, additional_ics, show_progress, offset = 2)
+        ret = basins_fractions(bmap, pics; N = length(icsampler), additional_ics, show_progress, offset = 2)
         fs = pics isa AbstractVector ? ret[1] : ret # if fractions also return labels.
         # deepcopy is important here as attractor container always referrenced
         prev_attractors = deepcopy(extract_attractors(bmap))

--- a/src/continuation/continuation_ascm_generic.jl
+++ b/src/continuation/continuation_ascm_generic.jl
@@ -149,30 +149,29 @@ function global_continuation(
         end
         # prepare the initial conditions
         pics = generate_ics(icsampler, p)
+        # TODO: Make basin_fractions always return labels in this function
         # and finally call basin fractions; it knows how to do all calculations given the bmap
-        ret = basins_fractions(bmap, pics; N = length(icsampler), additional_ics, show_progress, offset = 2)
-        fs = pics isa AbstractVector ? ret[1] : ret # if fractions also return labels.
-        # deepcopy is important here as attractor container always referrenced
-        prev_attractors = deepcopy(extract_attractors(bmap))
-        update_sampler!(sampler, what_do_we_need)
+        fs, labels = basins_fractions(bmap, pics; N = length(icsampler), additional_ics, show_progress, offset = 2)
+        update_sampler!(sampler, labels)
         # Now, check if the sampler requires us to re-sample at the current parameter
         while resampling_required(sampler)
-            # Do something something,
-            # Generate new ICs,
+            pics = generate_ics(icsampler, p)
+            fs, labels = basins_fractions(bmap, pics; N = length(icsampler), additional_ics, show_progress, offset = 2)
             # Do more somthing, and then finally update the sampler again
             # update the sampler type, if needed
-            update_sampler!(sampler, what_do_we_need)
+            update_sampler!(sampler, labels)
 
-            # The big question is: how can we re-use the initial conditions
-            # that were already generated and run through basin fractions...?
-            # We can modify basin fractions to return the labels of the init. cond.
-            # as well if this helps.
+            # TODO: for the future: find a way that the original initial conditions
+            # used before the `while` loop, are somehow kept into memory instead
+            # of being discarded.
         end
         # All the computations are done, and now we just store the result(s)
         # we don't match attractors here, this happens directly at the end.
         push!(fractions_cont, fs)
+        # deepcopy is important here as attractor container always referrenced
+        prev_attractors = deepcopy(extract_attractors(bmap))
         push!(attractors_cont, prev_attractors)
-        # show progress
+        # update progress bar
         showvalues = i < length(pcurve) ? [("pcurve index", i + 1)] : []
         ProgressMeter.next!(progress; showvalues)
     end

--- a/src/continuation/continuation_ascm_generic.jl
+++ b/src/continuation/continuation_ascm_generic.jl
@@ -149,7 +149,6 @@ function global_continuation(
         end
         # prepare the initial conditions
         pics = generate_ics(icsampler, p)
-        # TODO: Make basin_fractions always return labels in this function
         # and finally call basin fractions; it knows how to do all calculations given the bmap
         fs, labels = basins_fractions_labels(bmap, pics; additional_ics, show_progress, offset = 2)
         update_sampler!(sampler, labels)

--- a/src/continuation/continuation_ascm_generic.jl
+++ b/src/continuation/continuation_ascm_generic.jl
@@ -160,7 +160,6 @@ function global_continuation(
             # Do more somthing, and then finally update the sampler again
             # update the sampler type, if needed
             update_sampler!(sampler, labels)
-
             # TODO: for the future: find a way that the original initial conditions
             # used before the `while` loop, are somehow kept into memory instead
             # of being discarded.

--- a/src/continuation/continuation_grouping.jl
+++ b/src/continuation/continuation_grouping.jl
@@ -54,11 +54,11 @@ function mean_across_features(fs)
 end
 
 function global_continuation(
-        continuation::FeaturizeGroupAcrossParameter, pcurve, ics::InitialConditionSampler;
-        show_progress = true, samples_per_parameter = 100
+        continuation::FeaturizeGroupAcrossParameter, pcurve::Vector, ics::InitialConditionSampler;
+        show_progress = true,
     )
     (; bmap, info_extraction, par_weight) = continuation
-    spp, n = samples_per_parameter, length(pcurve)
+    spp, n = length(ics), length(pcurve)
     features = _get_features_pcurve(bmap, ics, n, spp, pcurve, show_progress)
 
     # This is a special clause for implementing the MCBB algorithm (weighting
@@ -77,23 +77,21 @@ function global_continuation(
     return fractions_cont, attractors_cont
 end
 
-function _get_features_pcurve(bmap::BasinMapFeaturizeGroup, ics, n, spp, pcurve, show_progress)
+function _get_features_pcurve(bmap::BasinMapFeaturizeGroup, sampler, n, spp, pcurve, show_progress)
     progress = ProgressMeter.Progress(
-        n;
-        desc = "Generating features", enabled = show_progress, offset = 2,
+        n; desc = "Generating features", enabled = show_progress, offset = 2,
     )
     # Extract the first possible feature to initialize the features container
-    feature = extract_features(bmap, ics; N = 1)
-    features = Vector{typeof(feature[1])}(undef, n * spp)
-    # Collect features
-    for (i, p) in enumerate(pcurve)
-        set_parameters!(bmap.ds, p)
-        if ics isa PerParameterInitialConditions
-            u0s = ics.generator(p, spp)
-        else
-            u0s = ics
-        end
-        current_features = extract_features(bmap, u0s; show_progress, N = spp)
+    u0s = generate_ics(sampler)
+    set_parameters!(bmap.ds, first(pcurve))
+    current_features = extract_features(bmap, u0s; show_progress, N = length(sampler))
+    features = Vector{typeof(current_features[1])}(undef, n * spp)
+    features[1:spp] .= current_features
+    # Collect features across parameter axis
+    for i in 2:length(pcurve)
+        set_parameters!(bmap.ds, pcurve[i])
+        u0s = generate_ics(sampler)
+        current_features = extract_features(bmap, u0s; show_progress, N = length(sampler))
         features[((i - 1) * spp + 1):(i * spp)] .= current_features
         ProgressMeter.next!(progress)
     end

--- a/src/continuation/continuation_grouping.jl
+++ b/src/continuation/continuation_grouping.jl
@@ -54,7 +54,7 @@ function mean_across_features(fs)
 end
 
 function global_continuation(
-        continuation::FeaturizeGroupAcrossParameter, pcurve, ics;
+        continuation::FeaturizeGroupAcrossParameter, pcurve, ics::InitialConditionSampler;
         show_progress = true, samples_per_parameter = 100
     )
     (; bmap, info_extraction, par_weight) = continuation

--- a/src/continuation/global_continuation_api.jl
+++ b/src/continuation/global_continuation_api.jl
@@ -72,10 +72,10 @@ function global_continuation end
     continuation_series(continuation_info, fillval = NaN)
 
 Transform a continuation quantity (a vector of dictionaries, each dictionary
-mapping attractor IDs to values of same type as `fillval`) to a dictionary of vectors
+mapping basin IDs to values of same type as `fillval`) to a dictionary of vectors
 where the `k` dictionary entry is the series of the continuation quantity corresponding to
-attractor with ID `k`. `fillval` denotes the value to assign in the series
-if the attractor with ID `k` does not exist at this particular series index.
+basin with ID `k`. `fillval` denotes the value to assign in the series
+if the basin with ID `k` does not exist at this particular series index.
 If the `continuation_info` is the attractors themselves, you likely want to
 use as `fillval` some empty state space set such as `StateSpaceSet{D}()`.
 """

--- a/src/continuation/global_continuation_api.jl
+++ b/src/continuation/global_continuation_api.jl
@@ -18,7 +18,7 @@ abstract type GlobalContinuationAlgorithm end
 
 Find and continue attractors (or representations of attractors) and properties of their
 basins across a parameter curve `pcurve` according to algorithm `gca` and
-by sampling initial conditions using `icsampler`
+by sampling initial conditions using `icsampler`.
 
 Possible subtypes of a `GlobalContinuationAlgorithm` are:
 
@@ -53,33 +53,20 @@ global continuation. Use [`hilbert_pcurve`](@ref) to cover multiparameter spaces
 
 ## Description
 
-`global_continuation` is the central function of the framework for global stability analysis
-illustrated in [Datseris2023](@cite).
+`global_continuation` is the central function for performing global continuation
+as outlined in our article [Datseris2026](@cite).
 
-The global continuation algorithm typically references an [`BasinMap`](@ref)
+The global continuation algorithm typically references a [`BasinMap`](@ref)
 which is used to find the attractors and basins of a dynamical system. Additional
 arguments that control how to continue/track/match attractors across a parameter range
 are given when creating `gca`.
 
-The basin fractions and the attractors (or some representation of them) are continued
-across the parameter range `prange`, for the parameter of the system with index `pidx`
-(any index valid in `DynamicalSystems.set_parameter!` can be used). In contrast to
-traditional continuation (see online Tutorial for a comparison), global continuation
-can be performed over arbitrary user-defined curves in parameter space.
-The second call signature with `pcurve` allows for this possibility. In this case
-`pcurve` is a vector of iterables, where each iterable maps parameter indices
-to parameter values. These iterables can be dictionaries, named tuples, `Vector{Pair}`,
-anything that can be given in `set_parameters!`. We recommend to use dictionaries.
-Regardless, the sequence of the iterables defines a curve in parameter space.
-In fact, the version with `prange, pidx` simply defines
-`pcurve = [Dict(pidx => p) for p in prange]` and calls the second method.
+The basin properties and the attractors (or some representation of them) are continued
+across the parameter curve, whose elements are simply given to `DynamicalSystems.set_parameter!s`
+to update system parameters. This is fundamentally different to local continuation,
+see the online documentation or our article for details.
 """
-function global_continuation(alg::GlobalContinuationAlgorithm, prange::AbstractVector, pidx, sampler; kw...)
-    # everything is propagated to the curve setting
-    pcurve = [Dict(pidx => p) for p in prange]
-    return global_continuation(alg, pcurve, sampler; kw...)
-end
-
+function global_continuation end
 
 """
     continuation_series(continuation_info, fillval = NaN)

--- a/src/continuation/global_continuation_api.jl
+++ b/src/continuation/global_continuation_api.jl
@@ -25,8 +25,8 @@ Possible subtypes of a `GlobalContinuationAlgorithm` are:
 - [`AttractorSeedContinueMatch`](@ref)
 - [`FeaturizeGroupAcrossParameter`](@ref)
 
-`pcurve` is a vector of dictionaries, each dictionary mapping parameter indices to values.
-This defines an arbitrary curve in the whole parameter space of the dynamical system.
+`pcurve` is a `Vector` of dictionaries, each dictionary mapping parameter indices to values.
+This defines an arbitrary curve in the parameter space of the dynamical system.
 
 `icsampler` is a subtype of [`InitialConditionSampler`](@ref) and provides instructions
 for how to sample initial conditions to explore the state space during the continuation.
@@ -34,13 +34,13 @@ for how to sample initial conditions to explore the state space during the conti
 Return:
 
 1. `fractions_cont::Vector{Dict{Int, Float64}}`. The fractions of basins of attraction.
-   `fractions_cont[i]` is a dictionary mapping attractor IDs to their basin fraction
+   `fractions_cont[i]` is a dictionary mapping basin IDs to their basin fraction
    at the `i`-th parameter combination.
    -  This output is different if you are using [`StabilityQuantifiersAccumulator`](@ref)
       in combination with [`AttractorSeedContinueMatch`](@ref). See the docstring
       of [`StabilityQuantifiersAccumulator`](@ref) for more details.
-2. `attractors_cont::Vector{Dict{Int, <:Any}}`. The continued attractors.
-   `attractors_cont[i]` is a dictionary mapping attractor ID to the
+2. `attractors_cont::Vector{Dict{Int, SSSet}}`. The continued attractors.
+   `attractors_cont[i]` is a dictionary mapping basin ID to its
    attractor set at the `i`-th parameter combination.
 
 See the function [`continuation_series`](@ref) if you wish to transform the output(s)

--- a/src/continuation/global_continuation_api.jl
+++ b/src/continuation/global_continuation_api.jl
@@ -57,13 +57,13 @@ global continuation. Use [`hilbert_pcurve`](@ref) to cover multiparameter spaces
 as outlined in our article [Datseris2026](@cite).
 
 The global continuation algorithm typically references a [`BasinMap`](@ref)
-which is used to find the attractors and basins of a dynamical system. Additional
+which is used to find basins and corresponding attractors of a dynamical system. Additional
 arguments that control how to continue/track/match attractors across a parameter range
 are given when creating `gca`.
 
 The basin properties and the attractors (or some representation of them) are continued
-across the parameter curve, whose elements are simply given to `DynamicalSystems.set_parameter!s`
-to update system parameters. This is fundamentally different to local continuation,
+across the parameter curve, whose elements are simply given to `DynamicalSystems.set_parameters!`
+to update system parameters. This is fundamentally different to local (traditional) continuation,
 see the online documentation or our article for details.
 """
 function global_continuation end

--- a/src/continuation/global_continuation_api.jl
+++ b/src/continuation/global_continuation_api.jl
@@ -1,11 +1,11 @@
 export global_continuation, GlobalContinuationAlgorithm, continuation_series, stability_quantifiers_along_continuation
-export PerParameterInitialConditions
+include("sampler_api.jl")
 
 """
     GlobalContinuationAlgorithm
 
 Supertype of all algorithms used in [`global_continuation`](@ref).
-Each algorithm typically references an [`BasinMap`](@ref),
+Each algorithm typically references a [`BasinMap`](@ref),
 as well as contains more information for how to continue/track/match attractors
 across a parameter range.
 
@@ -14,25 +14,22 @@ See [`global_continuation`](@ref) for more.
 abstract type GlobalContinuationAlgorithm end
 
 """
-    global_continuation(gca::GlobalContinuationAlgorithm, prange, pidx, ics; kwargs...)
-    global_continuation(gca::GlobalContinuationAlgorithm, pcurve, ics; kwargs...)
+    global_continuation(gca::GlobalContinuationAlgorithm, pcurve, icsampler; kwargs...)
 
-Find and continue attractors (or representations of attractors)
-and the fractions of their basins of attraction across a parameter curve `pcurve`
-by sampling given initial conditions `ics` according to algorithm `gca`.
+Find and continue attractors (or representations of attractors) and properties of their
+basins across a parameter curve `pcurve` according to algorithm `gca` and
+by sampling initial conditions using `icsampler`
 
 Possible subtypes of a `GlobalContinuationAlgorithm` are:
 
 - [`AttractorSeedContinueMatch`](@ref)
 - [`FeaturizeGroupAcrossParameter`](@ref)
 
-`ics` are the initial conditions to use when sampling the state space.
-They can be specified in one of three ways:
+`pcurve` is a vector of dictionaries, each dictionary mapping parameter indices to values.
+This defines an arbitrary curve in the whole parameter space of the dynamical system.
 
-1. A set vector of initial conditions (vector of vectors).
-2. A 0-argument function that generates random initial conditions.
-3. The special type [`PerParameterInitialConditions`](@ref) that allows
-   different initial conditions for different parameter values.
+`icsampler` is a subtype of [`InitialConditionSampler`](@ref) and provides instructions
+for how to sample initial conditions to explore the state space during the continuation.
 
 Return:
 
@@ -46,15 +43,13 @@ Return:
    `attractors_cont[i]` is a dictionary mapping attractor ID to the
    attractor set at the `i`-th parameter combination.
 
-See the function [`continuation_series`](@ref) if you wish to transform the output
+See the function [`continuation_series`](@ref) if you wish to transform the output(s)
 to an alternative format. There is no difference between single or multi parameter
 global continuation. Use [`hilbert_pcurve`](@ref) to cover multiparameter spaces.
 
 ## Keyword arguments
 
 - `show_progress = true`: display a progress bar of the computation.
-- `samples_per_parameter = 100`: amount of initial conditions sampled at each parameter
-  combination from `ics` if `ics` is a function instead of set initial conditions.
 
 ## Description
 
@@ -83,19 +78,6 @@ function global_continuation(alg::GlobalContinuationAlgorithm, prange::AbstractV
     # everything is propagated to the curve setting
     pcurve = [Dict(pidx => p) for p in prange]
     return global_continuation(alg, pcurve, sampler; kw...)
-end
-
-"""
-    PerParameterInitialConditions(generator)
-
-Wrapper around a function `generator`, to be called as
-`generator(parameters, N::Int)`.
-It inputs the current parameter(s) of a [`global_continuation`](@ref)
-(elements of `pcurve`), and generates a vector of `N` initial conditions.
-Note that elements of `pcurve` are recommended to be dictionaries.
-"""
-struct PerParameterInitialConditions{F}
-    generator::F
 end
 
 

--- a/src/continuation/sampler_api.jl
+++ b/src/continuation/sampler_api.jl
@@ -140,4 +140,5 @@ function update_sampler!(sampler::BayesianUpdateSampler, labels, args...)
         counter += n_box
     end
     # Processing stuff
+    return nothing
 end

--- a/src/continuation/sampler_api.jl
+++ b/src/continuation/sampler_api.jl
@@ -70,10 +70,10 @@ Base.length(s::PrescribedICs) = length(s.ics)
     PerParameterICs(f, N::Int) <: InitialConditionSampler
 
 Wrapper around a function `f`, to be called as
-`f(parameters, N)`.
+`f(parameters)`.
 It inputs the current parameter(s) of a [`global_continuation`](@ref)
-(elements of `pcurve` which are always a dictionary),
-and ouputs an iterable of `N` initial conditions.
+(elements of `pcurve` which are always a dictionary), and outputs
+a random initial condition.
 The sampler generates overall `N` initial conditions.
 """
 struct PerParameterInitialConditions{F} <: InitialConditionSampler
@@ -124,6 +124,7 @@ function generate_ics(sampler::BayesianUpdateSampler)
         end
         append!(all_ics, ics)
     end
+    return all_ics
 end
 
 function update_sampler!(sampler::BayesianUpdateSampler, labels, args...)
@@ -134,7 +135,7 @@ function update_sampler!(sampler::BayesianUpdateSampler, labels, args...)
         labels_for_box = view(labels, counter:(counter + n_box))
         # then make a decision on the η and box flag and whatever
         # update bayesian
-        η = update
+        η = update_somehow(labels_for_box)
         # then update the box flag
         boxes_flags[box_index] = η < 0 ? true : false
         counter += n_box

--- a/src/continuation/sampler_api.jl
+++ b/src/continuation/sampler_api.jl
@@ -13,9 +13,6 @@ Concerete subtypes are:
 - [`RandomICSampler`]
 - [`PrescribedICs`]
 - [`PerParameterICs`](@ref)
-- [`BayesianUpdateSampler`](@ref)
-
-
 """
 abstract type InitialConditionSampler end
 
@@ -52,8 +49,8 @@ struct RandomICSampler::F <: InitialConditionSampler
     f::F
     N::Int
 end
-
 RandomICSampler(N::Int, args...; kw...) = RandomICSampler(statespace_sampler(args...; kw...)[1], N)
+generate_ics(p::RandomICSampler, args...) = (p.f() for _ in 1:p.N)
 
 """
     PrescribedICs(u0s::AbstractVector) <: InitialConditionSampler
@@ -64,6 +61,7 @@ Wrapper around a container of initial conditions that simply provides
 struct PrescribedICs{V<:AbstractVector} <: InitialConditionSampler
     ics::V
 end
+generate_ics(p::PrescribedICs, args...) = p.ics
 
 """
     PerParameterICs(f, N::Int) <: InitialConditionSampler
@@ -76,12 +74,13 @@ and ouputs an initial condition. It generates `N` initial conditions
 at a given parameter.
 """
 struct PerParameterInitialConditions{F}
-    generator::F
+    f::F
     N::Int
 end
+generate_ics(p::PerParameterInitialConditions, params, args...) = (p.f(params) for _ in 1:p.N)
 
 """
-    Alex's paper.
+Alex's paper.
 """
 struct BayesianUpdateSampler::F <: InitialConditionSampler
     f::F

--- a/src/continuation/sampler_api.jl
+++ b/src/continuation/sampler_api.jl
@@ -5,14 +5,15 @@ export RandomICSampler, PerParameterICs, PerParameterInitialConditions
     InitialConditionSampler
 
 Data structure deciding how to sample initial conditions during
-[`global_continuation`](@ref). It defines an extendable interface
-based on the internal functions `generate_ics, update_sampler!, resampling_required`.
-
+[`global_continuation`](@ref).
 Concerete subtypes are:
 
 - [`RandomICSampler`]
 - [`PrescribedICs`]
 - [`PerParameterICs`](@ref)
+
+`InitialConditionSampler` defines a currently experimental extendable interface
+based on the internal functions `generate_ics, update_sampler!, resampling_required`.
 """
 abstract type InitialConditionSampler end
 Base.length(s::InitialConditionSampler) = s.N
@@ -80,7 +81,7 @@ struct PerParameterInitialConditions{F} <: InitialConditionSampler
     f::F
     N::Int
 end
-generate_ics(p::PerParameterInitialConditions, params, args...) = p.f(params, p.N)
+generate_ics(p::PerParameterInitialConditions, params, args...) = (p.f(params) for _ in p.N)
 
 """
     BayesianUpdateSampler(dense_sampler, sparse_sampler, γ = 0.5) <: InitialConditionSampler

--- a/src/continuation/sampler_api.jl
+++ b/src/continuation/sampler_api.jl
@@ -1,0 +1,83 @@
+export InitialConditionSampler, generate_ics, update_sampler!
+export PerParameterInitialConditions
+
+"""
+    InitialConditionSampler
+
+Data structure deciding how to sample initial conditions during
+[`global_continuation`](@ref). It defines an extendable interface
+based on the internal functions [`generate_ics`](@ref) and [`inform_sampler!`](@ref).
+
+Concerete subtypes are:
+
+- [`RandomICSampler`]
+- [`PrescribedICs`]
+- [`PerParameterICs`](@ref)
+- [`BayesianUpdateSampler`](@ref)
+
+
+"""
+abstract type InitialConditionSampler end
+
+# what should be inputs here? parameters for sure, anything else?
+function generate_ics end
+
+function update_sampler!(sampler, args...)
+    return nothing
+end
+
+"""
+    RandomICSampler(f::Function, N::Int) <: InitialConditionSampler
+
+Wrapper around a function `f`, to be called as
+`f() -> u`. When called, it generates a random initial condition.
+The sampler generates overall `N` initial conditions.
+
+The following convenience signature is also provided
+
+    RandomICSampler(N::Int, args...; kw...)
+
+which propagates `args, kw` to [`statespace_sampler`](@ref) and uses the generated
+sampler as the function `f`.
+"""
+struct RandomICSampler::F <: InitialConditionSampler
+    f::F
+    N::Int
+end
+
+RandomICSampler(N::Int, args...; kw...) = RandomICSampler(statespace_sampler(args...; kw...)[1], N)
+
+"""
+    PrescribedICs(u0s::AbstractVector) <: InitialConditionSampler
+
+Wrapper around a container of initial conditions that simply provides
+`u0s` as the sampled initial conditions.
+"""
+struct PrescribedICs{V<:AbstractVector} <: InitialConditionSampler
+    ics::V
+end
+
+"""
+    PerParameterICs(f, N::Int) <: InitialConditionSampler
+
+Wrapper around a function `f`, to be called as
+`f(parameters) -> u`.
+It inputs the current parameter(s) of a [`global_continuation`](@ref)
+(elements of `pcurve` which are always a dictionary),
+and ouputs an initial condition. It generates `N` initial conditions
+at a given parameter.
+"""
+struct PerParameterInitialConditions{F}
+    generator::F
+    N::Int
+end
+
+"""
+    Alex's paper.
+"""
+struct BayesianUpdateSampler::F <: InitialConditionSampler
+    f::F
+    Ndense::Int
+    Nsparse::Int
+    γ::Float64
+end

--- a/src/continuation/sampler_api.jl
+++ b/src/continuation/sampler_api.jl
@@ -90,6 +90,7 @@ struct BayesianUpdateSampler{D, S} <: InitialConditionSampler
     dense_sampler::D
     sparse_sampler::S
     γ::Float64
+    more_fields
 end
 
 function generate_ics(sampler::BayesianUpdateSampler)
@@ -99,4 +100,8 @@ function generate_ics(sampler::BayesianUpdateSampler)
     else
         return generate_ics(sampler.sparse_sampler)
     end
+end
+
+function update_sampler!(sampler::BayesianUpdateSampler, args...)
+    # Processing stuff
 end

--- a/src/continuation/sampler_api.jl
+++ b/src/continuation/sampler_api.jl
@@ -94,13 +94,24 @@ struct BayesianUpdateSampler{D, S, R <: HRectangle} <: InitialConditionSampler
     β::Float64
     λ::Float64
     boxes::Vector{R}
+    boxes_flags::Vector{Bool} # same size as `boxes`
     resampling_necessary::Bool
     more_fields
 end
 
+# Sketch for boxes
+# each box has either `dense_n` or `sparse_n`
+
+# if you have a total of `N` i.c.
+# and you know the `boxes_flags`, then you know exactly which ones of the total `N`
+# are in each box.
+
+# This way, you can generate a _single_ vector of initial conditions
+# (although its size would change at each step of the continuation depending
+# on which boxes get sparse or dense `n`)
+
 function generate_ics(sampler::BayesianUpdateSampler)
     # This function utilizes `resampling_necessary`.
-
     all_ics = []
     # loop through boxes
     for (boxi, box) in enumerate(sampler.boxes)
@@ -115,6 +126,18 @@ function generate_ics(sampler::BayesianUpdateSampler)
     end
 end
 
-function update_sampler!(sampler::BayesianUpdateSampler, args...)
+function update_sampler!(sampler::BayesianUpdateSampler, labels, args...)
+    # first, analyze labels per-box
+    counter = 1
+    for box_index in eachindex(sampler.boxes)
+        n_box = boxes_flags[box_index] ? sampler.dense_n : sampler.sparse_n
+        labels_for_box = view(labels, counter:(counter + n_box))
+        # then make a decision on the η and box flag and whatever
+        # update bayesian
+        η = update
+        # then update the box flag
+        boxes_flags[box_index] = η < 0 ? true : false
+        counter += n_box
+    end
     # Processing stuff
 end

--- a/src/continuation/sampler_api.jl
+++ b/src/continuation/sampler_api.jl
@@ -1,5 +1,5 @@
 export InitialConditionSampler, generate_ics, update_sampler!
-export PerParameterInitialConditions
+export RandomICSampler, PerParameterICs, PerParameterInitialConditions
 
 """
     InitialConditionSampler
@@ -15,6 +15,7 @@ Concerete subtypes are:
 - [`PerParameterICs`](@ref)
 """
 abstract type InitialConditionSampler end
+Base.length(s::InitialConditionSampler) = s.N
 
 """
     generate_ics(sampler::InitialConditionsSampler, p::Dict)
@@ -62,22 +63,23 @@ struct PrescribedICs{V<:AbstractVector} <: InitialConditionSampler
     ics::V
 end
 generate_ics(p::PrescribedICs, args...) = p.ics
+Base.length(s::PrescribedICs) = length(s.ics)
 
 """
     PerParameterICs(f, N::Int) <: InitialConditionSampler
 
 Wrapper around a function `f`, to be called as
-`f(parameters) -> u`.
+`f(parameters, N)`.
 It inputs the current parameter(s) of a [`global_continuation`](@ref)
 (elements of `pcurve` which are always a dictionary),
-and ouputs an initial condition. It generates `N` initial conditions
-at a given parameter.
+and ouputs an iterable of `N` initial conditions.
+The sampler generates overall `N` initial conditions.
 """
 struct PerParameterInitialConditions{F}
     f::F
     N::Int
 end
-generate_ics(p::PerParameterInitialConditions, params, args...) = (p.f(params) for _ in 1:p.N)
+generate_ics(p::PerParameterInitialConditions, params, args...) = p.f(params, N)
 
 """
 Alex's paper.

--- a/src/continuation/sampler_api.jl
+++ b/src/continuation/sampler_api.jl
@@ -86,19 +86,28 @@ generate_ics(p::PerParameterInitialConditions, params, args...) = p.f(params, p.
 
 From Alex's paper.
 """
-struct BayesianUpdateSampler{D, S} <: InitialConditionSampler
-    dense_sampler::D
-    sparse_sampler::S
+struct BayesianUpdateSampler{D, S, R <: HRectangle} <: InitialConditionSampler
+    dense_n::Int
+    sparse_n::Int
     γ::Float64
+    β::Float64
+    λ::Float64
+    boxes::Vector{R}
     more_fields
 end
 
 function generate_ics(sampler::BayesianUpdateSampler)
-    η = compute_log_bayes_factor(sampler.γ)
-    if η < 0
-        return genereate_ics(sampler.dense_sampler)
-    else
-        return generate_ics(sampler.sparse_sampler)
+    all_ics = []
+    # loop through boxes
+    for (boxi, box) in enumerate(sampler.boxes)
+        # for each box, compute η
+        η = somehow
+        if η < 0
+            ics = random_ics_from_box(box, dense_n)
+        else
+            ics = random_ics_from_box(box, sparse_n)
+        end
+        append!(all_ics, ics)
     end
 end
 

--- a/src/continuation/sampler_api.jl
+++ b/src/continuation/sampler_api.jl
@@ -75,11 +75,11 @@ It inputs the current parameter(s) of a [`global_continuation`](@ref)
 and ouputs an iterable of `N` initial conditions.
 The sampler generates overall `N` initial conditions.
 """
-struct PerParameterInitialConditions{F}
+struct PerParameterInitialConditions{F} <: InitialConditionSampler
     f::F
     N::Int
 end
-generate_ics(p::PerParameterInitialConditions, params, args...) = p.f(params, N)
+generate_ics(p::PerParameterInitialConditions, params, args...) = p.f(params, p.N)
 
 """
 Alex's paper.

--- a/src/continuation/sampler_api.jl
+++ b/src/continuation/sampler_api.jl
@@ -95,7 +95,7 @@ struct BayesianUpdateSampler{D, S, R <: HRectangle} <: InitialConditionSampler
     β::Float64
     λ::Float64
     boxes::Vector{R}
-    boxes_flags::Vector{Bool} # same size as `boxes`
+    boxes_flags::Vector{Bool} # same size as `boxes`, true if resampling is required for this box
     resampling_necessary::Bool
     more_fields
 end
@@ -144,3 +144,5 @@ function update_sampler!(sampler::BayesianUpdateSampler, labels, args...)
     # Processing stuff
     return nothing
 end
+
+resampling_required(sampler::BayesianUpdateSampler) = any(sampler.boxes_flags)

--- a/src/continuation/sampler_api.jl
+++ b/src/continuation/sampler_api.jl
@@ -45,7 +45,7 @@ The following convenience signature is also provided
 which propagates `args, kw` to [`statespace_sampler`](@ref) and uses the generated
 sampler as the function `f`.
 """
-struct RandomICSampler::F <: InitialConditionSampler
+struct RandomICSampler{F} <: InitialConditionSampler
     f::F
     N::Int
 end
@@ -82,7 +82,7 @@ generate_ics(p::PerParameterInitialConditions, params, args...) = (p.f(params) f
 """
 Alex's paper.
 """
-struct BayesianUpdateSampler::F <: InitialConditionSampler
+struct BayesianUpdateSampler{F} <: InitialConditionSampler
     f::F
     Ndense::Int
     Nsparse::Int

--- a/src/continuation/sampler_api.jl
+++ b/src/continuation/sampler_api.jl
@@ -19,12 +19,20 @@ Concerete subtypes are:
 """
 abstract type InitialConditionSampler end
 
-# what should be inputs here? parameters for sure, anything else?
+"""
+    generate_ics(sampler::InitialConditionsSampler, p::Dict)
+
+Generate initial condititions from the given sampler, optionally utilizing
+the parameters of the current continuation step.
+"""
 function generate_ics end
 
-function update_sampler!(sampler, args...)
-    return nothing
-end
+"""
+    update_sampler!(sampler::InitialConditionsSampler, args...)
+
+Todo, decide `args`.
+"""
+update_sampler!(sampler, args...) = nothing
 
 """
     RandomICSampler(f::Function, N::Int) <: InitialConditionSampler

--- a/src/continuation/sampler_api.jl
+++ b/src/continuation/sampler_api.jl
@@ -1,4 +1,4 @@
-export InitialConditionSampler, generate_ics, update_sampler!
+export InitialConditionSampler
 export RandomICSampler, PerParameterICs, PerParameterInitialConditions
 
 """
@@ -6,7 +6,7 @@ export RandomICSampler, PerParameterICs, PerParameterInitialConditions
 
 Data structure deciding how to sample initial conditions during
 [`global_continuation`](@ref). It defines an extendable interface
-based on the internal functions [`generate_ics`](@ref) and [`inform_sampler!`](@ref).
+based on the internal functions `generate_ics, update_sampler!, resampling_required`.
 
 Concerete subtypes are:
 
@@ -31,6 +31,7 @@ function generate_ics end
 Todo, decide `args`.
 """
 update_sampler!(sampler, args...) = nothing
+resampling_required(sampler) = false
 
 """
     RandomICSampler(f::Function, N::Int) <: InitialConditionSampler
@@ -93,10 +94,13 @@ struct BayesianUpdateSampler{D, S, R <: HRectangle} <: InitialConditionSampler
     β::Float64
     λ::Float64
     boxes::Vector{R}
+    resampling_necessary::Bool
     more_fields
 end
 
 function generate_ics(sampler::BayesianUpdateSampler)
+    # This function utilizes `resampling_necessary`.
+
     all_ics = []
     # loop through boxes
     for (boxi, box) in enumerate(sampler.boxes)

--- a/src/continuation/sampler_api.jl
+++ b/src/continuation/sampler_api.jl
@@ -82,11 +82,21 @@ end
 generate_ics(p::PerParameterInitialConditions, params, args...) = p.f(params, p.N)
 
 """
-Alex's paper.
+    BayesianUpdateSampler(dense_sampler, sparse_sampler, γ = 0.5) <: InitialConditionSampler
+
+From Alex's paper.
 """
-struct BayesianUpdateSampler{F} <: InitialConditionSampler
-    f::F
-    Ndense::Int
-    Nsparse::Int
+struct BayesianUpdateSampler{D, S} <: InitialConditionSampler
+    dense_sampler::D
+    sparse_sampler::S
     γ::Float64
+end
+
+function generate_ics(sampler::BayesianUpdateSampler)
+    η = compute_log_bayes_factor(sampler.γ)
+    if η < 0
+        return genereate_ics(sampler.dense_sampler)
+    else
+        return generate_ics(sampler.sparse_sampler)
+    end
 end

--- a/src/continuation/sampler_api.jl
+++ b/src/continuation/sampler_api.jl
@@ -71,17 +71,17 @@ Base.length(s::PrescribedICs) = length(s.ics)
     PerParameterICs(f, N::Int) <: InitialConditionSampler
 
 Wrapper around a function `f`, to be called as
-`f(parameters)`.
+`f(parameters, N)`.
 It inputs the current parameter(s) of a [`global_continuation`](@ref)
 (elements of `pcurve` which are always a dictionary), and outputs
-a random initial condition.
+`N` initial conditions.
 The sampler generates overall `N` initial conditions.
 """
 struct PerParameterInitialConditions{F} <: InitialConditionSampler
     f::F
     N::Int
 end
-generate_ics(p::PerParameterInitialConditions, params, args...) = (p.f(params) for _ in p.N)
+generate_ics(p::PerParameterInitialConditions, params, args...) = p.f(params, p.N)
 
 """
     BayesianUpdateSampler(dense_sampler, sparse_sampler, γ = 0.5) <: InitialConditionSampler

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -32,3 +32,9 @@ end
 @deprecate AttractorsViaProximity BasinMapProximity
 @deprecate stability_measures_along_continuation stability_quantifiers_along_continuation
 @deprecate StabilityMeasuresAccumulator StabilityQuantifiersAccumulator
+
+function global_continuation(alg::GlobalContinuationAlgorithm, prange, pidx, sampler::InitialConditionSampler; kw...)
+    @warn "passing `prange, pidx` as inputs to `global_continuation` is deprecated. Pass a single `pcurve`."
+    pcurve = [Dict(pidx => p) for p in prange]
+    return global_continuation(alg, pcurve, sampler; kw...)
+end

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -33,8 +33,19 @@ end
 @deprecate stability_measures_along_continuation stability_quantifiers_along_continuation
 @deprecate StabilityMeasuresAccumulator StabilityQuantifiersAccumulator
 
-function global_continuation(alg::GlobalContinuationAlgorithm, prange, pidx, sampler::InitialConditionSampler; kw...)
+function global_continuation(alg::GlobalContinuationAlgorithm, prange, pidx, ics; kw...)
     @warn "passing `prange, pidx` as inputs to `global_continuation` is deprecated. Pass a single `pcurve`."
+    if !(ics isa InitialConditionSampler)
+        @warn "You must now pass a subtype of `InitialConditionSampler` explicitly to `global_continuation`.
+        Making the closest type for now..."
+        if ics isa AbstractVector
+            sampler = PrescribedICs(ics)
+        else
+            sampler = RandomICSampler(ics, 100)
+        end
+    else
+        sampler = ics
+    end
     pcurve = [Dict(pidx => p) for p in prange]
     return global_continuation(alg, pcurve, sampler; kw...)
 end

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -33,19 +33,19 @@ end
 @deprecate stability_measures_along_continuation stability_quantifiers_along_continuation
 @deprecate StabilityMeasuresAccumulator StabilityQuantifiersAccumulator
 
-function global_continuation(alg::GlobalContinuationAlgorithm, prange, pidx, ics; kw...)
+function global_continuation(alg, prange, pidx, ics; kw...)
     @warn "passing `prange, pidx` as inputs to `global_continuation` is deprecated. Pass a single `pcurve`."
-    if !(ics isa InitialConditionSampler)
-        @warn "You must now pass a subtype of `InitialConditionSampler` explicitly to `global_continuation`.
-        Making the closest type for now..."
-        if ics isa AbstractVector
-            sampler = PrescribedICs(ics)
-        else
-            sampler = RandomICSampler(ics, 100)
-        end
-    else
-        sampler = ics
-    end
     pcurve = [Dict(pidx => p) for p in prange]
+    return global_continuation(alg, pcurve, ics; kw...)
+end
+
+function global_continuation(alg::GlobalContinuationAlgorithm, pcurve::Vector, ics::Union{AbstractVector, Function}; kw...)
+    @warn "You must now pass a subtype of `InitialConditionSampler` explicitly to `global_continuation`.
+    Making the closest type for now..."
+    if ics isa AbstractVector
+        sampler = PrescribedICs(ics)
+    else
+        sampler = RandomICSampler(ics, 100)
+    end
     return global_continuation(alg, pcurve, sampler; kw...)
 end

--- a/src/mapping/attractor_mapping.jl
+++ b/src/mapping/attractor_mapping.jl
@@ -165,7 +165,7 @@ function basins_fractions_labels(bmap::BasinMap, ics;
         N;
         desc = "Running basin map:", PMKWARGS..., offset, enabled = show_progress
     )
-    labels = Vector{Int}(undef, fill_labels ? N : 0)
+    labels = Vector{Int32}(undef, fill_labels ? N : 0)
     ffs = if allows_mapper_u0(bmap)
         basins_fractions_individual(bmap, ics, N, progress, labels, additional_ics)
     else

--- a/src/mapping/attractor_mapping.jl
+++ b/src/mapping/attractor_mapping.jl
@@ -157,7 +157,7 @@ function basins_fractions(
         icscol = if ics isa AbstractVector
             copy(ics)
         else
-            StateSpaceSet([copy(ics()) for _ in 1:N])
+            StateSpaceSet([copy(_get_ic(ics, i)) for i in 1:N])
         end
         append!(icscol, additional_ics)
         basins_fractions_grouped(bmap, icscol, progress, labels)
@@ -202,6 +202,8 @@ function basins_fractions_grouped(bmap, ics, progress, labels)
     error("Must be implemented for bmap of type $(nameof(typeof(bmap)))")
 end
 
+# Generator dispatch is needed because that's what `Sampler` types return
+_get_ic(ics::Base.Generator, i) = first(iterate(ics))
 _get_ic(ics::Function, i) = ics()
 _get_ic(ics::AbstractVector, i) = ics[i]
 

--- a/src/mapping/attractor_mapping.jl
+++ b/src/mapping/attractor_mapping.jl
@@ -20,8 +20,6 @@ export BasinMap,
     StabilityQuantifiersAccumulator,
     finalize_accumulator
 
-ValidICS = Union{AbstractVector, Function, Base.Generator}
-
 #########################################################################################
 # BasinMap structure definition
 #########################################################################################
@@ -152,8 +150,7 @@ end
 Same as [`basins_fractions`](@ref) but return two outputs: the fractions dictionary
 and a vector of integers which contains the labels of the provided initial conditions.
 """
-function basins_fractions_labels(bmap, ics;
-        bmap::BasinMap, ics::ValidICS;
+function basins_fractions_labels(bmap::BasinMap, ics;
         show_progress = true, N = 1000,
         # This is an internal keyword used by `basin_fractions`
         fill_labels = true,

--- a/src/mapping/attractor_mapping.jl
+++ b/src/mapping/attractor_mapping.jl
@@ -146,7 +146,7 @@ function basins_fractions(
     N = used_container ? length(ics) : N
     progress = ProgressMeter.Progress(
         N;
-        desc = "Mapping i.c. to attractors:", PMKWARGS..., offset, enabled = show_progress
+        desc = "Running basin map:", PMKWARGS..., offset, enabled = show_progress
     )
     labels = Vector{Int}(undef, used_container ? N : 0)
     ffs = if allows_mapper_u0(bmap)

--- a/src/mapping/attractor_mapping.jl
+++ b/src/mapping/attractor_mapping.jl
@@ -19,7 +19,7 @@ export BasinMap,
     StabilityQuantifiersAccumulator,
     finalize_accumulator
 
-ValidICS = Union{AbstractVector, Function}
+ValidICS = Union{AbstractVector, Function, Base.Generator}
 
 #########################################################################################
 # BasinMap structure definition
@@ -153,10 +153,11 @@ function basins_fractions(
         basins_fractions_individual(bmap, ics, N, progress, labels, additional_ics)
     else
         # collect all initial conditions
-        icscol = if ics isa Function
-            StateSpaceSet([copy(ics()) for _ in 1:N])
-        else
+        # TODO: We do some unecessary copying here I feel like... maybe we can improve?
+        icscol = if ics isa AbstractVector
             copy(ics)
+        else
+            StateSpaceSet([copy(ics()) for _ in 1:N])
         end
         append!(icscol, additional_ics)
         basins_fractions_grouped(bmap, icscol, progress, labels)

--- a/src/mapping/attractor_mapping.jl
+++ b/src/mapping/attractor_mapping.jl
@@ -7,6 +7,7 @@ export BasinMap,
     BasinMapFeaturizeGroup,
     ClusteringConfig,
     basins_fractions,
+    basins_fractions_labels,
     convergence_and_basins_of_attraction,
     convergence_and_basins_fractions,
     convergence_time,
@@ -102,7 +103,10 @@ Approximate the state space fractions `fs` of the basins of attraction of a dyna
 system by mapping initial conditions to attractors using `bmap`
 (which contains a reference to a [`DynamicalSystem`](@ref)).
 The fractions are simply the ratios of how many initial conditions ended up
-at each attractor.
+at each attractor. Return the fractions as a dictionary mapping
+basin IDs (integers) to their fractions.
+If you also want to obtain a vector of labels corresponding to each initial condition,
+use the function `basins_fractions_labels` instead.
 
 Initial conditions to use are defined by `ics`. It can be:
 * an `AbstractVector` of initial conditions, in which case all are used.
@@ -133,22 +137,38 @@ See also [`convergence_and_basins_fractions`](@ref).
 * `N = 1000`: Number of random initial conditions to generate in case `ics` is a function.
 * `show_progress = true`: Display a progress bar of the process.
 """
-function basins_fractions(
+function basins_fractions(bmap::BasinMap, ics; kw...)
+    fs, labels = basins_fractions_labels(bmap, ics; fill_labels = false, kw...)
+    return fs
+end
+
+"""
+    basins_fractions_labels(
+        bmap::BasinMap,
+        ics::Union{AbstractVector, Function};
+        kwargs...
+    )
+
+Same as [`basins_fractions`](@ref) but return two outputs: the fractions dictionary
+and a vector of integers which contains the labels of the provided initial conditions.
+"""
+function basins_fractions_labels(bmap, ics;
         bmap::BasinMap, ics::ValidICS;
         show_progress = true, N = 1000,
+        # This is an internal keyword used by `basin_fractions`
+        fill_labels = true,
         # this is an internal keyword used in the ASCM global conitnuation
         additional_ics = [],
         # and this is another internal keyword for the offset of the progress bar
         # for when this function is called in global continuation
         offset = 0,
     )
-    used_container = ics isa AbstractVector
-    N = used_container ? length(ics) : N
+    N = ics isa AbstractVector ? length(ics) : N
     progress = ProgressMeter.Progress(
         N;
         desc = "Running basin map:", PMKWARGS..., offset, enabled = show_progress
     )
-    labels = Vector{Int}(undef, used_container ? N : 0)
+    labels = Vector{Int}(undef, fill_labels ? N : 0)
     ffs = if allows_mapper_u0(bmap)
         basins_fractions_individual(bmap, ics, N, progress, labels, additional_ics)
     else
@@ -162,7 +182,7 @@ function basins_fractions(
         append!(icscol, additional_ics)
         basins_fractions_grouped(bmap, icscol, progress, labels)
     end
-    if used_container
+    if fill_labels
         return ffs, labels
     else
         return ffs

--- a/src/mapping/grouping/attractor_mapping_featurizing.jl
+++ b/src/mapping/grouping/attractor_mapping_featurizing.jl
@@ -166,7 +166,7 @@ function extract_features(
 end
 
 function extract_features_single(bmap, ics; progress, N)
-    N = (typeof(ics) <: Function) ? N : size(ics, 1) # number of actual ICs
+    N = (typeof(ics) <: AbstractVector) ? length(ics) : N # number of actual ICs
     ds = referenced_dynamical_system(bmap)
     first_feature = extract_feature(ds, _get_ic(ics, 1), bmap)
     feature_vector = Vector{typeof(first_feature)}(undef, N)
@@ -181,7 +181,7 @@ end
 
 using OhMyThreads: @tasks, @local
 function extract_features_threaded(bmap, ics; progress, N)
-    N = (typeof(ics) <: Function) ? N : size(ics, 1) # number of actual ICs
+    N = (typeof(ics) <: AbstractVector) ? length(ics) : N # number of actual ICs
     # systems = [deepcopy(bmap.ds) for _ in 1:(Threads.nthreads() - 1)]
     # pushfirst!(systems, bmap.ds)
     first_feature = extract_feature(bmap.ds, _get_ic(ics, 1), bmap)

--- a/test/continuation/grouping_continuation.jl
+++ b/test/continuation/grouping_continuation.jl
@@ -93,6 +93,7 @@ if DO_EXTENSIVE_TESTS
         ds = DeterministicIteratedMap(henon_rule, ones(2), [a, b])
         ps = range(0.6, 1.1; length = 11)
         pidx = 1
+        pcurve = [Dict(1 => p) for p in ps]
         sampler, = statespace_sampler(HRectangle([-2, -2], [2, 2]), 1234)
 
         # Feature based on period.
@@ -115,9 +116,10 @@ if DO_EXTENSIVE_TESTS
             T = 10, Ttr = 2000, threaded = true
         )
         gap = FeaturizeGroupAcrossParameter(bmap; par_weight = 0.0)
+        sampler = RandomICSampler(sampler, 100)
         fractions_cont, attractors_cont = global_continuation(
-            gap, ps, pidx, sampler;
-            samples_per_parameter = 100, show_progress = false
+            gap, pcurve, sampler;
+            show_progress = false
         )
 
         for (i, p) in enumerate(ps)

--- a/test/continuation/grouping_continuation.jl
+++ b/test/continuation/grouping_continuation.jl
@@ -28,16 +28,17 @@ using Random
     ds = DiscreteDynamicalSystem(dumb_map, [0.0, 0.0], [r])
 
     sampler, = statespace_sampler(HRectangle([-3.0, -3.0], [3.0, 3.0]), 1234)
+    sampler = RandomICSampler(sampler, 100)
 
     rrange = range(0, 2; length = 21)
-    ridx = 1
+    pcurve = [Dict(1 => r) for r in rrange]
 
     featurizer(a, t) = a[end]
     clusterspecs = Attractors.GroupViaClustering(optimal_radius_method = "silhouettes", max_used_features = 200)
     bmap = Attractors.BasinMapFeaturizeGroup(ds, featurizer, clusterspecs; T = 20, threaded = false)
     gap = FeaturizeGroupAcrossParameter(bmap; par_weight = 0.0)
     fractions_cont, attractors_cont = global_continuation(
-        gap, rrange, ridx, sampler; show_progress = false
+        gap, pcurve, sampler; show_progress = false
     )
 
     for (i, r) in enumerate(rrange)

--- a/test/continuation/seed_continue_generic.jl
+++ b/test/continuation/seed_continue_generic.jl
@@ -102,7 +102,7 @@ end
         ics = [SVector(v, w + I) for w in grid[2] for v in grid[1]]
         return ics
     end
-    icsgen = PerParameterInitialConditions(make_ics)
+    icsgen = PerParameterInitialConditions(make_ics, 25)
 
     featurizer(A, t) = A[end]
     gconfig = GroupViaPairwiseComparison(threshold = 0.25, rescale_features = false)
@@ -111,7 +111,7 @@ end
 
     pcurve = [Dict(1 => r) for r in rs]
     fractions_cont, attractors_cont = global_continuation(
-        gca, pcurve, icsgen; samples_per_parameter = 25, show_progress = false
+        gca, pcurve, icsgen; show_progress = false
     )
 
     # all times 2 attractors, never the 0.0 attractor

--- a/test/continuation/seed_continue_generic.jl
+++ b/test/continuation/seed_continue_generic.jl
@@ -29,7 +29,7 @@ using Random
     grid = (xg, yg)
     mapper1 = BasinMapRecurrences(ds, grid; sparse = true, show_progress = false)
 
-    sampler, = statespace_sampler(grid, 1234)
+    sampler = RandomICSampler(1000, grid, 1234)
 
     rrange = range(0, 2; length = 20)
     ridx = 1
@@ -48,23 +48,12 @@ using Random
 
     @testset "case: $(i)" for (i, bmap) in enumerate(mappers)
         algo = AttractorSeedContinueMatch(bmap)
-
-        if i < 4
-            fractions_cont, a = global_continuation(
-                algo, rrange, ridx, sampler;
-                show_progress = false, samples_per_parameter = 1000
-            )
-        else # test parameter curve version
-            pcurve = [[1 => r, 2 => 1.1] for r in rrange]
-            fractions_cont, a = global_continuation(
-                algo, pcurve, sampler;
-                show_progress = false, samples_per_parameter = 1000
-            )
-        end
-
+        pcurve = [[1 => r, 2 => 1.1] for r in rrange]
+        fractions_cont, a = global_continuation(
+            algo, pcurve, sampler; show_progress = false,
+        )
 
         for (i, r) in enumerate(rrange)
-
             fs = fractions_cont[i]
             if r < 0.5
                 k = sort!(collect(keys(fs)))
@@ -80,7 +69,6 @@ using Random
             @test sum(values(fs)) ≈ 1
         end
     end
-
 end
 
 @testset "parameter dependent ic" begin


### PR DESCRIPTION
The third argument to `global_continuation` now has to be an instance of a new type hierarchy, providing instructions on how to sample initial conditions during global continuation. This allow us to straightforwardly add new types in the future. It also takes care of the "messy" code we had so far, where various ways to specify initial conditions were allowed, but never as part of a common interface. 

I am thinking of establishing the same interface for the `basin_fractions` function. The only thing unclear is how to take care of "return labels or not" problem. At the moment, I think I will just create a new function `basin_fractions_labels` or something, as that code was also always messy... 