### PR TITLE
Calculate basin entropy from sampled basins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This release accompanies the release of our paper "Global continuation as a comp
 
 ## New features
 
+- `basin_entropy` function has been extended to work for sampled basins by using
+  nearest neighbor searches and KD trees.
+- `basin_entropy` is now also optionally estimated by `StabilityQuantifierAccumulator`.
 - New function `hilbert_pcurve`. It conveniently uses Hilbert curves to create a parameter curve efficiently spanning a multidimensional space. To be used with `global_continuation`.
 - `StabilityQuantifiersAccumulator` allows for an `extras` input to calculate arbitrary
   additional quantities after sampling the state space.

--- a/src/basins/fractality_of_basins.jl
+++ b/src/basins/fractality_of_basins.jl
@@ -77,6 +77,7 @@ basin_entropy(BoA::ArrayBasinsOfAttraction{<:Integer}, es::NTuple{D, <:Integer})
 
 """
     basin_entropy(BoA::SampledBasinsOfAttraction{<:Integer}, n = 100; kw...) -> Sb, Sbb
+    basin_entropy(points::AbstractVector, labels::AbstractVector, n = 100; kw...) -> Sb, Sbb
 
 Return the basin entropy `Sb` and basin boundary entropy `Sbb` of sampled basins
 using a nearest-neighbor estimate. For each sampled point, a local neighborhood is
@@ -90,6 +91,11 @@ from the relative frequencies of basin IDs in this neighborhood.
 function basin_entropy(BoA::SampledBasinsOfAttraction{<:Integer}, n::Integer = 100; metric = Euclidean())
     points = BoA.sampled_points
     ids = BoA.points_ids
+    return basin_entropy(points, ids, n; metric)
+end
+
+# This function was made by GPT-5.3-Codex
+function basin_entropy(points::AbstractVector, ids::AbstractVector{<:Integer}, n::Int; metric = Euclidean())
     N = length(points)
     N ≤ 1 && return 0.0, 0.0
 

--- a/src/basins/fractality_of_basins.jl
+++ b/src/basins/fractality_of_basins.jl
@@ -7,7 +7,7 @@ export uncertainty_exponent, basins_fractal_dimension, basins_fractal_test, basi
 Return the basin entropy [Daza2016](@cite) `Sb` and basin boundary entropy `Sbb`
 of the given `basins` of attraction by considering `ε`-sized boxes along each dimension.
 
-The second function signature exists for backwards compatibility. 
+The second function signature exists for backwards compatibility.
 
 ## Description
 
@@ -75,6 +75,73 @@ end
 
 basin_entropy(BoA::ArrayBasinsOfAttraction{<:Integer}, es::NTuple{D, <:Integer}) where {D} = basin_entropy(BoA.basins, es)
 
+"""
+    basin_entropy(BoA::SampledBasinsOfAttraction{<:Integer}, n = 100; kw...) -> Sb, Sbb
+
+Return the basin entropy `Sb` and basin boundary entropy `Sbb` of sampled basins
+using a nearest-neighbor estimate. For each sampled point, a local neighborhood is
+formed by its `n` nearest neighbors, and the probabilities ``p_{ij}`` are estimated
+from the relative frequencies of basin IDs in this neighborhood.
+
+## Keyword arguments
+
+- `metric = Euclidean()`: the metric to use when constructing the KDTree.
+"""
+function basin_entropy(BoA::SampledBasinsOfAttraction{<:Integer}, n::Integer = 100; metric = Euclidean())
+    points = BoA.sampled_points
+    ids = BoA.points_ids
+    N = length(points)
+    N ≤ 1 && return 0.0, 0.0
+
+    tree = searchstructure(KDTree, points, metric)
+    nneigh = min(n, N - 1)
+    kquery = min(n + 1, N)
+    idxs = zeros(Int, kquery)
+    dists = zeros(Float64, kquery)
+
+    Sb = 0.0
+    Nb = 0
+    local_idxs = zeros(Int, nneigh)
+    skip = Returns(false)
+    sort_result = false
+
+    for i in eachindex(points)
+        Neighborhood.NearestNeighbors.knn_point!(
+            tree, points[i], sort_result, dists, idxs, skip
+        )
+
+        found = 0
+        for j in eachindex(idxs)
+            idx = idxs[j]
+            if idx == i
+                continue
+            end
+            found += 1
+            local_idxs[found] = idx
+            found == nneigh && break
+        end
+
+        # Fallback: in degenerate cases where self wasn't returned by knn query,
+        # fill remaining slots directly from the returned nearest-neighbor indices.
+        if found < nneigh
+            for j in eachindex(idxs)
+                found += 1
+                local_idxs[found] = idxs[j]
+                found == nneigh && break
+            end
+        end
+
+        neighbor_ids = @view ids[local_idxs]
+        uvals = unique(neighbor_ids)
+        if length(uvals) > 1
+            Nb += 1
+            Sb += _box_entropy(neighbor_ids, uvals)
+        end
+    end
+
+    return Sb / N, Nb == 0 ? 0.0 : Sb / Nb
+end
+
 function _box_entropy(box_values, unique_vals = unique(box_values))
     h = 0.0
     for v in unique_vals
@@ -86,14 +153,11 @@ end
 
 
 """
-    basin_entropy(BoA::ArrayBasinsOfAttraction, ε = 20, Ntotal = 1000) -> test_res, Sbb
     basins_fractal_test(basins; ε = 20, Ntotal = 1000) -> test_res, Sbb
 
 Perform an automated test to decide if the boundary of the basins has fractal structures
 based on the method of Puy et al. [Puy2021](@cite).
 Return `test_res` (`:fractal` or `:smooth`) and the mean basin boundary entropy.
-
-The second function signature exists for backwards compatibility. 
 
 ## Keyword arguments
 
@@ -185,7 +249,7 @@ linreg(x, y) = hcat(fill!(similar(x), 1), x) \ y
 Estimate the fractal dimension `d` of the boundary between basins of attraction using
 a box-counting algorithm for the boxes that contain at least two different basin IDs.
 
-The second function signature exists for backwards compatibility. 
+The second function signature exists for backwards compatibility.
 
 ## Keyword arguments
 
@@ -258,7 +322,7 @@ The output `α` is the estimation of the uncertainty exponent using the box-coun
 dimension of the boundary by fitting a line in the `log.(N_ε)` vs `log.(1/ε)` curve.
 However it is recommended to analyze the curve directly for more accuracy.
 
-The second function signature exists for backwards compatibility. 
+The second function signature exists for backwards compatibility.
 
 ## Keyword arguments
 * `range_ε = 2:maximum(size(basins))÷20` is the range of sizes of the ball to

--- a/src/continuation/continuation_stability_quantifiers.jl
+++ b/src/continuation/continuation_stability_quantifiers.jl
@@ -102,6 +102,10 @@ There are two reasons to use this method:
 - `ε = nothing`: given to [`BasinMapProximity`](@ref).
 - `proximity_mapper_options = NamedTuple()`: extra keywords for `BasinMapProximity`.
 - `distance, finite_time, weighting_distribution`: given to [`StabilityQuantifiersAccumulator`](@ref).
+- `basin_entropy = true`: given to [`StabilityQuantifiersAccumulator`](@ref) to enable/disable
+    sampled-basin entropy quantifiers.
+- `n_basin_entropy = 100`: given to [`StabilityQuantifiersAccumulator`](@ref) as the number
+    of nearest neighbors used by sampled-basin entropy quantifiers.
 - `samples_per_parameter = 1000`: how many samples to use when estimating stability quantifiers
   via [`StabilityQuantifiersAccumulator`](@ref). Ignored when `ics` is not a function.
 
@@ -122,6 +126,8 @@ function stability_quantifiers_along_continuation(
         ε = nothing,
         weighting_distribution = EverywhereUniform(),
         finite_time = 1.0,
+        basin_entropy = true,
+        n_basin_entropy = 100,
         samples_per_parameter = 1000,
         distance = Centroid(),
         proximity_mapper_options = NamedTuple(),
@@ -175,7 +181,9 @@ function stability_quantifiers_along_continuation(
         accumulator = StabilityQuantifiersAccumulator(
             BasinMapProximity(ds, attractors; ε = ε_, proximity_mapper_options...);
             weighting_distribution = wd, finite_time = ft,
-            distance = d
+            distance = d,
+            basin_entropy = basin_entropy,
+            n_basin_entropy = n_basin_entropy,
         )
 
         if ics isa PerParameterInitialConditions

--- a/src/nonlocal/stability_quantifiers_accumulator.jl
+++ b/src/nonlocal/stability_quantifiers_accumulator.jl
@@ -62,6 +62,10 @@ more rirogously and is estimated more accurately for a proximity bmap.
   condition `u0` and an attractor `A`. Estimated via `set_distance([u0], A, distance)`.
 * `idistances = [Euclidean()]`: A vector of point distances given to [`intermingedness`](@ref)
   for calculating the intermingledness of basins of attraction.
+  If this is empty, intermingledness is not calculated.
+* `n_basin_entropy = 100`: number of nearest neighbors used for sampled-basin entropy.
+* `basin_entropy = true`: if `true`, compute sampled-basin entropy quantifiers; if `false`,
+  skip them because they can be expensive.
 
 ## Description
 
@@ -154,6 +158,8 @@ The word "distance" here refers to the distance established by the `distance` ke
   be produced, each ending with the number `i`. Because intermingledness is expensive to
   compute for a large number of initial conditions, you can disable this by providing
   an empty vector to `idistances`. See [`intermingedness`](@ref) for more information.
+* `basin_entropy` and `boundary_basin_entropy`: estimated from the sampled basins with the
+  nearest-neighbor method (if `basin_entropy = true`).
 
 ### Extra quantifiers
 
@@ -199,12 +205,15 @@ struct StabilityQuantifiersAccumulator{AM <: BasinMap, V <: AbstractVector, F, M
     distance::M
     extras::E
     idistances::X
+    basin_entropy::Bool
+    n_basin_entropy::Int
 end
 
 function StabilityQuantifiersAccumulator(
         bmap::BasinMap, extr = Dict();
         finite_time = 1.0, weighting_distribution = EverywhereUniform(),
         distance = Centroid(), idistances = [Euclidean()],
+        basin_entropy::Bool = true, n_basin_entropy::Integer = 100,
     )
     reset_mapper!(bmap)
     ds = referenced_dynamical_system(bmap)
@@ -214,6 +223,9 @@ function StabilityQuantifiersAccumulator(
     M = typeof(distance)
     W = typeof(weighting_distribution)
     extras = _convert_to_dict(extr)
+    if n_basin_entropy < 1
+        throw(ArgumentError("`n_basin_entropy` must be a positive integer"))
+    end
     return StabilityQuantifiersAccumulator{AM, V, F, M, W, typeof(extras), typeof(idistances)}(
         bmap,
         Vector{V}(),
@@ -223,7 +235,9 @@ function StabilityQuantifiersAccumulator(
         weighting_distribution,
         distance,
         extras,
-        idistances
+        idistances,
+        basin_entropy,
+        Int(n_basin_entropy),
     )
 end
 
@@ -480,9 +494,16 @@ function finalize_accumulator(accumulator::StabilityQuantifiersAccumulator)
         output["intermingledness$(i)"] = m
     end
 
+    # sampled-basin object reused by optional quantifiers
+    sboa = SampledBasinsOfAttraction(bs, attractors, u0s)
+    if accumulator.basin_entropy
+        Sb, Sbb = basin_entropy(sboa, accumulator.n_basin_entropy)
+        output["basin_entropy"] = Dict(id => (id == -1 ? NaN : Sb) for id in ids)
+        output["boundary_basin_entropy"] = Dict(id => (id == -1 ? NaN : Sbb) for id in ids)
+    end
+
     # extra quantifiers requested by the user
     if !isempty(accumulator.extras)
-        sboa = SampledBasinsOfAttraction(bs, attractors, u0s)
         for (key, f) in accumulator.extras
             output[key] = f(sboa, ds)
         end

--- a/test/basins/uncertainty_tests.jl
+++ b/test/basins/uncertainty_tests.jl
@@ -78,3 +78,17 @@ end
     basins = rand(Int, 50, 50)
     @test_throws ArgumentError basin_entropy(basins, 7)
 end
+
+@testset "Sampled basin entropy" begin
+    points = StateSpaceSet([SVector(-2.0), SVector(-1.0), SVector(1.0), SVector(2.0)])
+    basins = Int[1, 1, 2, 2]
+    attractors = Dict(
+        1 => StateSpaceSet([SVector(-1.5)]),
+        2 => StateSpaceSet([SVector(1.5)]),
+    )
+    sboa = SampledBasinsOfAttraction(basins, attractors, points)
+
+    Sb, Sbb = basin_entropy(sboa, 2)
+    @test Sb ≈ log(2)
+    @test Sbb ≈ log(2)
+end

--- a/test/nonlocal/stability_quantifiers_accumulator.jl
+++ b/test/nonlocal/stability_quantifiers_accumulator.jl
@@ -352,6 +352,69 @@ end
     end
 end
 
+@testset "sampled basin entropy quantifiers" begin
+    function dumb_map(z, p, n)
+        x, y = z
+        r = p[1]
+        if r < 0.5
+            return SVector(0.0, 0.0)
+        else
+            if x ≥ 0
+                return SVector(r, r)
+            else
+                return SVector(-r, -r)
+            end
+        end
+    end
+
+    r = 1.0
+    grid = ([-1, 0, 1], [-1, 0, 1])
+    dynamics = DiscreteDynamicalSystem(dumb_map, [1.0, 1.0], [r])
+    bmap = BasinMapRecurrences(dynamics, grid; sparse = false)
+    A = ics_from_grid(grid)
+
+    accumulator = StabilityQuantifiersAccumulator(
+        bmap;
+        n_basin_entropy = 2,
+        idistances = [],
+    )
+    for u0 in A
+        accumulator(u0)
+    end
+    results = finalize_accumulator(accumulator)
+
+    @test haskey(results, "basin_entropy")
+    @test haskey(results, "boundary_basin_entropy")
+    @test results["basin_entropy"] isa Dict
+    @test results["boundary_basin_entropy"] isa Dict
+
+    nids = length(unique(v for v in accumulator.bs if v != -1))
+    hmax = log(nids)
+    bvals = [v for v in values(results["basin_entropy"]) if !isnan(v)]
+    bbvals = [v for v in values(results["boundary_basin_entropy"]) if !isnan(v)]
+    @test !isempty(bvals)
+    @test !isempty(bbvals)
+    @test all(0.0 ≤ v ≤ hmax for v in bvals)
+    @test all(0.0 ≤ v ≤ hmax for v in bbvals)
+
+    pcurve = [[1 => rr] for rr in [0.5, 1.0]]
+    attractors_cont = [
+        Dict(1 => StateSpaceSet([SVector(0.0, 0.0)])),
+        Dict(2 => StateSpaceSet([SVector(1.0, 1.0)]), 1 => StateSpaceSet([SVector(-1.0, -1.0)])),
+    ]
+    quantifiers_cont = stability_quantifiers_along_continuation(
+        dynamics, attractors_cont, pcurve, A;
+        ε = 0.1,
+        n_basin_entropy = 2,
+        show_progress = false,
+        proximity_mapper_options = (Ttr = 0, stop_at_Δt = false, horizon_limit = 1.0e2, consecutive_lost_steps = 10000),
+    )
+    @test haskey(quantifiers_cont, "basin_entropy")
+    @test haskey(quantifiers_cont, "boundary_basin_entropy")
+    @test length(quantifiers_cont["basin_entropy"]) == 2
+    @test length(quantifiers_cont["boundary_basin_entropy"]) == 2
+end
+
 
 @testset "accumulator with featurizer" begin
     function dumb_map(z, p, n)


### PR DESCRIPTION
Also add it in the stability accumulator. Thus, now basin entropy can be calculated during global continuation nearly for free (cost of KDTree can be expensive!)