### PR TITLE
Dedicated type for output of `global_continuation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ This release accompanies the release of our paper "Global continuation as a comp
   - When continuing with `StabilityQuantifierAccumulator` the third field `.quantifiers`
     contains that info.
   - For backwards compatibility `iterate` works on `GlobalContinuationOutput` and returns
-    the first two fields. This will be breaking user code that used the accumulator though.
+    the continued fractions and attractors as was the case before v2.
+    This will be breaking user code that used the accumulator though.
 - **BREAKING**: The `basins_fractions` output structure has been reworked. Now `basins_fractions` always returns only one output regardless of inputs: the fractions.
   A new function `basins_fractions_labels` returns also the labels.
 - **BREAKING**: All deprecations existing before v2 release have been removed. Add v1.39 explicitly to resolve this if need be.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This release accompanies the release of our paper "Global continuation as a comp
   of `InitialConditionSampler` instead.
 - **DEPRECATED**: Passing a vector of initial conditions or a sampling function to
   `global_continuation` is now deprecated. Use the `InitialConditionSampler` interface.
+- **BREAKING**: This sampler object must also be passed to `stability_quantifiers_along_continuation`.
 - **BREAKING**: `PerParameterInitialConditions` has been renamed to `PerParameterICs`.
 - **BREAKING**: Anything related to the `par_weight` input to `FeaturizeGroupAcrossParameter` has been removed (it was so far deprecated).
 - **BREAKING**: `info_extraction` keyword argument to `FeaturizeGroupAcrossParameter` is now an optional positional argument.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This release accompanies the release of our paper "Global continuation as a comp
   of `InitialConditionSampler` instead.
 - **DEPRECATED**: Passing a vector of initial conditions or a sampling function to
   `global_continuation` is now deprecated. Use the `InitialConditionSampler` interface.
+- **BREAKING**: `PerParameterInitialConditions` has been renamed to `PerParameterICs`.
 - **BREAKING**: Anything related to the `par_weight` input to `FeaturizeGroupAcrossParameter` has been removed (it was so far deprecated).
 - **BREAKING**: `info_extraction` keyword argument to `FeaturizeGroupAcrossParameter` is now an optional positional argument.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ This release accompanies the release of our paper "Global continuation as a comp
   of `InitialConditionSampler` instead.
 - **DEPRECATED**: Passing a vector of initial conditions or a sampling function to
   `global_continuation` is now deprecated. Use the `InitialConditionSampler` interface.
-
+- **BREAKING**: Anything related to the `par_weight` input to `FeaturizeGroupAcrossParameter` has been removed (it was so far deprecated).
+- **BREAKING**: `info_extraction` keyword argument to `FeaturizeGroupAcrossParameter` is now an optional positional argument.
 
 ### Renaming of stability measures
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,23 +2,16 @@
 
 This release accompanies the release of our paper "Global continuation as a complement to traditional continuation and bifurcation analysis".
 
-## New features
-
-- `basin_entropy` function has been extended to work for sampled basins by using
-  nearest neighbor searches and KD trees.
-- `basin_entropy` is now also optionally estimated by `StabilityQuantifierAccumulator`.
-- New function `hilbert_pcurve`. It conveniently uses Hilbert curves to create a parameter curve efficiently spanning a multidimensional space. To be used with `global_continuation`.
-- `StabilityQuantifiersAccumulator` allows for an `extras` input to calculate arbitrary
-  additional quantities after sampling the state space.
-- `continuation_series` now allows for mixed type outputs, so that the fill value
-  can be of different type (e.g., `missing`) than the continuation quantity.
-- New API for instructing `global_continuation` on how to sample initial conditions
-  structured around a new abstract type `InitialConditionSampler`.
-  - Concrete types include `RandomICSampler, PrescribedICs, PerParameterICs` and more
-    to come in the future.
-
 ## Breaking changes and Deprecations
 
+- **BREAKING**: The output of `global_continuation` is now a single centralized type
+  `GlobalContinuationOutput` that contains all quantities computed during a continuation
+  and is flexible in allowing additional output to be added in the future.
+  - Its first two fields are the attractors and fractions that are continued.
+  - When continuing with `StabilityQuantifierAccumulator` the third field `.quantifiers`
+    contains that info.
+  - For backwards compatibility `iterate` works on `GlobalContinuationOutput` and returns
+    the first two fields. This will be breaking user code that used the accumulator though.
 - **BREAKING**: The `basins_fractions` output structure has been reworked. Now `basins_fractions` always returns only one output regardless of inputs: the fractions.
   A new function `basins_fractions_labels` returns also the labels.
 - **BREAKING**: All deprecations existing before v2 release have been removed. Add v1.39 explicitly to resolve this if need be.
@@ -30,6 +23,7 @@ This release accompanies the release of our paper "Global continuation as a comp
   of `InitialConditionSampler` instead.
 - **DEPRECATED**: Passing a vector of initial conditions or a sampling function to
   `global_continuation` is now deprecated. Use the `InitialConditionSampler` interface.
+
 
 ### Renaming of stability measures
 
@@ -50,7 +44,7 @@ The `AttractorMapper` constructions have been fully renamed. All following renam
 This better represents what these constructs are about, which is also reflected in the updated docstring of `BasinMap`.
 Throughout the docs, `mapper` variable has been renamed to `bmap` as well.
 
-## Aggregation reworked
+### Aggregation reworked
 
 Aggregation of attractors, also along a continuation, has been reworked.
 This rework comes from the odd and undisclosed way matching worked for
@@ -65,6 +59,22 @@ distances of feature centroids (instead of attractor centroids).
 - **BREAKING**: Removed the `featurizer` and `group_config` keyword arguments from `finalize_accumulator`. Attractor aggregation for stability measures is now
   done explicitly via `aggregate_continuation`.
 - **BREAKING** `finalize_accumulator` now returns only the dictionary of stability measures (previously it also returned the dictionary of attractors as a second value). The attractors are always those of the accumulator's mapper and can be obtained with `extract_attractors(accumulator)`.
+
+## New features
+
+- `basin_entropy` function has been extended to work for sampled basins by using
+  nearest neighbor searches and KD trees.
+- `basin_entropy` is now also optionally estimated by `StabilityQuantifierAccumulator`.
+- New function `hilbert_pcurve`. It conveniently uses Hilbert curves to create a parameter curve efficiently spanning a multidimensional space. To be used with `global_continuation`.
+- `StabilityQuantifiersAccumulator` allows for an `extras` input to calculate arbitrary
+  additional quantities after sampling the state space.
+- `continuation_series` now allows for mixed type outputs, so that the fill value
+  can be of different type (e.g., `missing`) than the continuation quantity.
+- New API for instructing `global_continuation` on how to sample initial conditions
+  structured around a new abstract type `InitialConditionSampler`.
+  - Concrete types include `RandomICSampler, PrescribedICs, PerParameterICs` and more
+    to come in the future.
+
 
 # v1.39
 

--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -344,3 +344,13 @@ series = {KDD'96}
   year = {2026},
   copyright = {arXiv.org perpetual,  non-exclusive license}
 }
+
+@misc{Datseris2026,
+      title={Global continuation as a complement to traditional continuation and bifurcation analysis},
+      author={George Datseris and Andreas Morr and Muhammed Fadera and Juergen Kurths},
+      year={2026},
+      eprint={2607.09332},
+      archivePrefix={arXiv},
+      primaryClass={nlin.CD},
+      url={https://arxiv.org/abs/2607.09332},
+}

--- a/docs/src/bfkit_comparison.jl
+++ b/docs/src/bfkit_comparison.jl
@@ -219,12 +219,12 @@ bmap = BasinMapRecurrences(
     consecutive_lost_steps = 100,
 )
 
-sampler = RandomICSampler(1000, statespace_sampler(grid))
+sampler = RandomICSampler(1000, grid)
 
 algo = AttractorSeedContinueMatch(StabilityQuantifiersAccumulator(bmap))
-
+pcurve = [Dict(pidx => p) for p in prange]
 @time quantifiers_cont, attractors_cont = global_continuation(
-    algo, prange, pidx, sampler
+    algo, pcurve, sampler
 )
 
 plot_attractors_curves(

--- a/docs/src/bfkit_comparison.jl
+++ b/docs/src/bfkit_comparison.jl
@@ -219,12 +219,12 @@ bmap = BasinMapRecurrences(
     consecutive_lost_steps = 100,
 )
 
-sampler, = statespace_sampler(grid)
+sampler = RandomICSampler(1000, statespace_sampler(grid))
 
 algo = AttractorSeedContinueMatch(StabilityQuantifiersAccumulator(bmap))
 
 @time quantifiers_cont, attractors_cont = global_continuation(
-    algo, prange, pidx, sampler; samples_per_parameter = 1_000
+    algo, prange, pidx, sampler
 )
 
 plot_attractors_curves(

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -478,7 +478,7 @@ fig
 
 ```
 
-## Basin fractions continuation in the magnetic pendulum
+## Global continuation in the magnetic pendulum
 
 Perhaps the simplest application of [`global_continuation`](@ref) is to produce a plot of how the fractions of attractors change as we continuously change the parameter we changed above to calculate tipping probabilities.
 
@@ -497,18 +497,17 @@ ds = ProjectedDynamicalSystem(ds, 1:2, [0.0, 0.0])
 bmap = BasinMapRecurrences(ds, (xg, yg); Δt = 1.0)
 # What parameter to change, over what range
 γγ = range(1, 0; length = 101)
-prange = [[1, 1, γ] for γ in γγ]
-pidx = :γs
+pcurve = [Dict(:γs => [1, 1, γ]) for γ in γγ]
 # important to make a sampler that respects the symmetry of the system
 region = HSphere(3.0, 2)
-sampler, = statespace_sampler(region, 1234)
+sampler = RandomICSampler(100, region, 1234)
 # continue attractors and basins:
 # `Inf` threshold fits here, as attractors move smoothly in parameter space
 rsc = RecurrencesFindAndMatch(bmap; threshold = Inf)
-fractions_cont, attractors_cont = global_continuation(
-    rsc, prange, pidx, sampler;
-    show_progress = false, samples_per_parameter = 100
+gco = global_continuation(
+    rsc, pcurve, sampler; show_progress = false,
 )
+fractions_cont, attractors_cont = gco.fractions, gco.attractors
 # Show some characteristic fractions:
 fractions_cont[[1, 50, 101]]
 ```
@@ -548,8 +547,9 @@ fig
 as you can see, two of the three fixed points, and their stability, do not depend at all on the parameter value, since this parameter value tunes the magnetic strength of only the third magnet. Nevertheless, the **fractions of basin of attraction** of all attractors depend strongly on the parameter. This is a simple example that highlights excellently how this new approach we propose here should be used even if one has already done a standard linearized bifurcation analysis.
 
 ## Featurizing and grouping across parameters (MCBB / FGAP)
+
 Here we showcase the example of the Monte Carlo Basin Bifurcation publication.
-For this, we will use [`FeaturizeGroupAcrossParameter`](@ref) while also providing a `par_weight = 1` keyword.
+For this, we will use [`FeaturizeGroupAcrossParameter`](@ref).
 However, we will not use a network of 2nd order Kuramoto oscillators (as done in the paper by Gelbrecht et al.) because it is too costly to run on CI.
 Instead, we will use "dummy" system which we know analytically the attractors and how they behave versus a parameter.
 
@@ -579,25 +579,25 @@ ds = DiscreteDynamicalSystem(dumb_map, [0., 0.], [r])
 
 
 ```@example MAIN
-sampler, = statespace_sampler(HRectangle([-3.0, -3.0], [3.0, 3.0]), 1234)
+sampler = RandomICSampler(100, HRectangle([-3.0, -3.0], [3.0, 3.0]), 1234)
 
 rrange = range(0, 2; length = 21)
-ridx = 1
+pcurve = [Dict(1 => r) for r in rrange]
 
 featurizer(a, t) = a[end]
 clusterspecs = GroupViaClustering(optimal_radius_method = "silhouettes", max_used_features = 200)
 bmap = BasinMapFeaturizeGroup(ds, featurizer, clusterspecs; T = 20, threaded = true)
-gap = FeaturizeGroupAcrossParameter(bmap; par_weight = 1.0)
-fractions_cont, clusters_info = global_continuation(
-    gap, rrange, ridx, sampler; show_progress = false
+gap = FeaturizeGroupAcrossParameter(bmap)
+gco = global_continuation(
+    gap, pcurve, sampler; show_progress = false
 )
-fractions_cont
+fractions_cont = gco.fractions
 ```
 
 Looking at the information of the "attractors" (here the clusters of the grouping procedure) does not make it clear which label corresponds to which kind of attractor, but we can look at the:
 
 ```@example MAIN
-clusters_info
+clusters_info = gco.attractors
 ```
 
 ## Using histograms and histogram distances as features
@@ -899,8 +899,6 @@ This special `matcher` achieves the following:
   the attractors are matched!
 
 
-
-
 ## [Aggregated stability quantifiers of a population model](@id aggregate_continuation_example)
 
 This example discusses aggregation of continuation results: where a dynamical system may have multiple attractors, but some of them share the same functional/operating state for the context of the system. In such cases, you want to aggregate attractors with similar function.
@@ -940,12 +938,12 @@ bmap = BasinMapRecurrences(ds, grid;
 # A short continuation in K₁ with few samples, to keep the example fast
 prange = range(0.91, 0.89; length = 5)
 pcurve = [Dict(1 => v) for v in prange]
-sampler, = statespace_sampler(grid, 1234)
+sampler = RandomICSampler(100, grid, 1234)
 alg = RecurrencesFindAndMatch(bmap; distance = StrictlyMinimumDistance())
-fractions_cont, attractors_cont = global_continuation(
-    alg, pcurve, sampler; samples_per_parameter = 100, show_progress = false
+gco = global_continuation(
+    alg, pcurve, sampler; show_progress = false
 )
-
+attractors_cont = gco.attractors
 length.(values.(attractors_cont)) # number of attractors at each step
 ```
 

--- a/docs/src/tutorial.jl
+++ b/docs/src/tutorial.jl
@@ -517,7 +517,7 @@ animate_attractors_continuation(ds, gco; savename = "curvecont.mp4");
 # to run through it again and estimate now all stability quantifiers.
 
 result = stability_quantifiers_along_continuation(
-    ds, attractors_cont, pcurve, sampler; ε = 0.1
+    ds, attractors_cont, pcurve, gcsampler; ε = 0.1
 )
 keys(result)
 

--- a/docs/src/tutorial.jl
+++ b/docs/src/tutorial.jl
@@ -487,6 +487,7 @@ matcher = MatchBySSSetDistance(use_vanished = true)
 ascm = AttractorSeedContinueMatch(bmap, matcher)
 
 gco = global_continuation(ascm, pcurve, gcsampler)
+attractors_cont = gco.attractors
 
 # and animate the result
 animate_attractors_continuation(ds, gco; savename = "curvecont.mp4");

--- a/docs/src/tutorial.jl
+++ b/docs/src/tutorial.jl
@@ -504,7 +504,7 @@ animate_attractors_continuation(ds, gco; savename = "curvecont.mp4");
 # is the basin fractions. This is primarily because it is computed automatically
 # as we find the different attractors. There are many more stability quantifiers
 # that could be more useful in different contexts. Attractors.jl offers
-# the unique possibility of estimating _almost all_ known quantifiers of stability in the
+# the unique possibility of estimating a multitude of known quantifiers of stability in the
 # literature of dynamical systems during a _single_ global continuation pass.
 # This is done with the [`StabilityQuantifiersAccumulator`](@ref) data structure.
 # You can visit its documentation string to learn about all different stability quantifiers.
@@ -512,8 +512,8 @@ animate_attractors_continuation(ds, gco; savename = "curvecont.mp4");
 # then either open an Issue and tell us about it or even better make a Pull Request and
 # contribute it yourself!
 
-# Using [`StabilityQuantifiersAccumulator`](@ref) is very easy. If we have already performed
-# a global continuation then we can utilize the function [`stability_quantifiers_along_continuation`](@ref)
+# Using [`StabilityQuantifiersAccumulator`](@ref) is very easy. If you have already performed
+# a global continuation then you can utilize the function [`stability_quantifiers_along_continuation`](@ref)
 # to run through it again and estimate now all stability quantifiers.
 
 result = stability_quantifiers_along_continuation(
@@ -606,9 +606,8 @@ matcher = MatchBySSSetDistance(use_vanished = true, threshold = 0.5)
 ascm = AttractorSeedContinueMatch(bmap, matcher)
 
 # and proceed as usual
-fractions_cont, attractors_cont = global_continuation(
-    ascm, pcurve, sampler; samples_per_parameter = 100
-)
+gcsampler = RandomICSampler(sampler, 100)
+fractions_cont, attractors_cont = global_continuation(ascm, pcurve, gcsampler)
 
 # The output is exactly of the same type, and as such very easy to post-process.
 # For example, let's find all parameter values that support an attractor

--- a/docs/src/tutorial.jl
+++ b/docs/src/tutorial.jl
@@ -2,7 +2,7 @@
 
 # ```@raw html
 # <video width="auto" controls loop>
-# <source src="../attracont_extra.mp4" type="video/mp4">
+# <source src="../globalcont_extra.mp4" type="video/mp4">
 # </video>
 # ```
 
@@ -52,7 +52,7 @@ Pkg.status(["Attractors", "CairoMakie", "OrdinaryDiffEqVerner"])
 # diffeq = (alg = Vern9(), abstol = 1e-9, reltol = 1e-9, dt = 0.01) # solver options
 # ds = CoupledODEs(modified_lorenz_rule, u0, p0; diffeq)
 
-# ## Define key input: an `AttractorMaper` that maps initial
+# ## Define key input: a `BasinMap` that maps initial
 # ## conditions to attractors of a `DynamicalSystem`
 # grid = (
 #     range(-15.0, 15.0; length = 150), # x
@@ -81,11 +81,13 @@ Pkg.status(["Attractors", "CairoMakie", "OrdinaryDiffEqVerner"])
 # params(θ) = [1 => 5 + 0.5cos(θ), 2 => 0.1 + 0.01sin(θ)]
 # angles = range(0, 2π; length = 101)
 # pcurve = params.(angles)
-# fractions_cont, attractors_cont = global_continuation(
-# 	algo, pcurve, sampler; samples_per_parameter = 1_000
+# gcoutput = global_continuation(
+# 	algo, pcurve, RandomICSampler(sampler, 1000)
 # )
 
 # ## and visualize the results
+# fractions_cont = gcoutput.fractions
+# attractors_cont = gcoutput.attractors
 # fig = plot_basins_attractors_curves(
 # 	fractions_cont, attractors_cont, A -> minimum(A[:, 1]), angles; add_legend = false
 # )
@@ -236,12 +238,7 @@ fs = basins_fractions(bmap, sampler)
 # To obtain the full basins, which is computationally much more expensive,
 # use [`basins_of_attraction`](@ref).
 
-# You can use alternative algorithms in [`basins_fractions`](@ref), see
-# the documentation of [`BasinMap`](@ref) for possible subtypes.
-# [`BasinMap`](@ref) defines an extendable interface and can be enriched
-# with other methods in the future!
-
-# ## Different Attractor Mapper
+# ## Different Basin Map
 
 # Attractors.jl utilizes composable interfaces throughout its functionality.
 # In the above example we used one particular method to find attractors,
@@ -299,37 +296,26 @@ plot_attractors(attractors3)
 
 # If you have heard before the word "continuation", then you are likely aware of the
 # **traditional continuation-based bifurcation analysis (CBA)** offered by many software,
-# such as AUTO, MatCont, and in Julia [BifurcationKit.jl](https://github.com/bifurcationkit/BifurcationKit.jl).
+# such as AUTO, CoCo, and in Julia [BifurcationKit.jl](https://github.com/bifurcationkit/BifurcationKit.jl).
 # These software perform **local continuation**.
 # Here we offer a completely different kind of continuation called **global continuation**.
+# For an extensive comparison of the two, see our paper [Datseris2026](@cite)
+# or have a look at the last paragraph in this tutorial.
+# From our article:
 
-# The local continuation continues the curves of individual _fixed
-# points (and under some conditions limit cycles)_ across the joint state-parameter space and
-# tracks their _local (linear) stability_.
-# This approach needs to manually be "re-run" for every individual branch of fixed points
-# or limit cycles.
-# The global continuation in Attractors.jl finds _all_ attractors, _including chaotic
-# or quasiperiodic ones_,
-# in the whole of the state space (that it searches in), without manual intervention.
-# It then continues all of these attractors concurrently along a parameter axis.
-# Additionally, the global continuation tracks a _nonlocal_ stability property which by
-# default is the basin fraction.
+# !!! "quote"
+#      Global continuation finds and continues in parallel (practically) all system attractors
+#      and their response to finite perturbations by synthesising information from the whole
+#      state space, while placing a focus on the qualities or observables of a dynamical
+#      system that the practitioner cares about in context.
 
 # Because all attractors are simultaneously
 # tracked across the parameter axis, the user may arbitrarily estimate _any_
 # property of the attractors and how it varies as the parameter varies.
-# A more detailed comparison between these two approaches can be found in [Datseris2023](@cite).
-# See also the [comparison page](@ref bfkit_comparison) in our docs
-# that attempts to do the same analysis of our Tutorial with traditional continuation software.
 
-# To perform a global continuation is surprisingly simple. First, we decide what parameter,
-# and what range of that parameter, to continue over:
-
-prange = 4.5:0.01:6
-pidx = 1 # index of the parameter
-
-# Then, we may call the [`global_continuation`](@ref) function.
-# We have to provide a continuation algorithm, which itself references an [`BasinMap`](@ref).
+# To perform a global continuation is surprisingly simple and requires only three
+# clear inputs. First, we need to decide the global continuation algorithm which also
+# references a [`BasinMap`](@ref).
 # In this example we will re-use the `bmap` to create the "flagship product" of Attractors.jl
 # which is the general [`AttractorSeedContinueMatch`](@ref).
 # This algorithm uses the `bmap` to find all attractors at each parameter value
@@ -341,39 +327,56 @@ pidx = 1 # index of the parameter
 
 ascm = AttractorSeedContinueMatch(bmap)
 
-# and call
+# The second input to global continuation is what parameter,
+# and what values of that parameter, to continue over:
 
-fractions_cont, attractors_cont = global_continuation(
-    ascm, prange, pidx, sampler; samples_per_parameter = 1_000
-)
+prange = 4.5:0.01:6
+pidx = 1 # index of the parameter
 
-# the output is given as two vectors. Each vector is a dictionary
-# mapping attractor IDs to their basin fractions, or their state space sets, respectively.
-# Both vectors have the same size as the parameter range.
-# For example, the attractors at the 34-th parameter value are:
+# Global continuation occurs over a prescribed parameter curve, so we convert this to
 
-attractors_cont[34]
+pcurve = [Dict(pidx => p) for p in prange]
+
+# Then, the third and final input is how, and how densely, to sample the state space.
+# Here we re-use the `sampler` and sample (per parameter value) 1000 initial conditions:
+
+gcsampler = RandomICSampler(sampler, 1000)
+
+# Then, we may call the [`global_continuation`](@ref) function.
+
+gco = global_continuation(ascm, pcurve, gcsampler)
+
+# This normally takes about a minute of compute depending on your computer.
+# The output is [`GlobalContinuationOutput`](@ref) which can contain a variety of information
+# but always contains the following two crucial pieces of information given as two vectors:
+
+fractions_cont = gco.fractions
+attractors_cont = gco.attractors;
+
+# Each vector is a dictionary
+# mapping basin IDs to their basin fractions, or their state space sets, respectively.
+# Both vectors have the same size as the parameter axis.
+# For example, the attractors at the 77-th parameter value are:
+
+attractors_cont[77]
 
 # If you want to transform the output to the alternative format of
 # a dictionary of vectors, use [`continuation_series`](@ref).
-# You typically don't have to though, because there is a fantastic convenience function
+# There is also a fantastic convenience function
 # for animating the attractors evolution, that utilizes things we have
 # already defined:
 
-animate_attractors_continuation(
-    ds, attractors_cont, fractions_cont, prange, pidx
-);
+animate_attractors_continuation(ds, gco)
 
 # ```@raw html
 # <video width="auto" controls loop>
-# <source src="../attracont.mp4" type="video/mp4">
+# <source src="../globalcont.mp4" type="video/mp4">
 # </video>
 # ```
 
 # Hah, how cool is that! The attractors pop in and out of existence like out of nowhere!
 # It can be difficult to find these attractors in traditional continuation software
-# where a rough estimate of the period is required! (It would also be too hard due to the presence
-# of chaos for most of the parameter values, but that's another issue!)
+# where a rough estimate of the period is required!
 
 # Now typically a continuation is visualized in a 2D plot where the x axis is the
 # parameter axis. We can do this with the convenience function:
@@ -384,7 +387,7 @@ fig = plot_basins_attractors_curves(
 
 # In the top panel are the basin fractions, by default plotted as stacked bars.
 # Bottom panel is a visualization of some feature(s) of the tracked attractors.
-# The argument `A -> minimum(A[:, 1])` is simply a function that maps
+# The argument `A -> minimum(A[:, 1])` is a function that maps
 # an attractor into a real number for plotting. A vector of such functions can be
 # given instead.
 
@@ -394,20 +397,21 @@ fig = plot_basins_attractors_curves(
 # keyword arguments like so:
 
 fig = animate_attractors_continuation(
-    ds, attractors_cont, fractions_cont, prange, pidx;
+    ds, gco;
     figure = (size = (600, 700),),
     axis = (ylabel = "y", xlabel = "x"),
-    savename = "attracont_extra.mp4",
+    savename = "globalcont_extra.mp4",
     add_legend = false,
     a2rs = [A -> minimum(A[:, 1]), A -> maximum(A[:, 2])],
     a2rs_ylabels = ["x-min", "y-max"],
     a2rs_ratio = 0.33,
     vline_kwargs = (linestyle = :dash, linewidth = 3, color = "red"),
+    prange,
 )
 
 # ```@raw html
 # <video width="auto" controls loop>
-# <source src="../attracont_extra.mp4" type="video/mp4">
+# <source src="../globalcont_extra.mp4" type="video/mp4">
 # </video>
 # ```
 
@@ -466,7 +470,7 @@ fig = plot_attractors_curves(
 # are two completely orthogonal steps, and (2) it is completely fine for
 # attractors to dissapear (and perhaps re-appear) during a global continuation.
 
-#For example, we can probe an elipsoid defined as
+# For example, we can probe an elipsoid defined as
 
 params(θ) = [1 => 5 + 0.5cos(θ), 2 => 0.1 + 0.01sin(θ)]
 θs = range(0, 2π; length = 101)
@@ -482,15 +486,10 @@ matcher = MatchBySSSetDistance(use_vanished = true)
 
 ascm = AttractorSeedContinueMatch(bmap, matcher)
 
-fractions_cont, attractors_cont = global_continuation(
-    ascm, pcurve, sampler; samples_per_parameter = 1_000
-)
+gco = global_continuation(ascm, pcurve, gcsampler)
 
 # and animate the result
-animate_attractors_continuation(
-    ds, attractors_cont, fractions_cont, pcurve;
-    savename = "curvecont.mp4"
-);
+animate_attractors_continuation(ds, gco; savename = "curvecont.mp4");
 
 # ```@raw html
 # <video width="auto" controls loop>

--- a/docs/src/tutorial.jl
+++ b/docs/src/tutorial.jl
@@ -78,9 +78,9 @@ Pkg.status(["Attractors", "CairoMakie", "OrdinaryDiffEqVerner"])
 # ## continue all attractors and their basin fractions across any arbigrary
 # ## curve in parameter space using a global continuation algorithm
 # algo = AttractorSeedContinueMatch(bmap)
-# params(θ) = [1 => 5 + 0.5cos(θ), 2 => 0.1 + 0.01sin(θ)]
+# ellipsoid(θ) = [1 => 5 + 0.5cos(θ), 2 => 0.1 + 0.01sin(θ)]
 # angles = range(0, 2π; length = 101)
-# pcurve = params.(angles)
+# pcurve = ellipsoid.(angles)
 # gcoutput = global_continuation(
 # 	algo, pcurve, RandomICSampler(sampler, 1000)
 # )
@@ -260,7 +260,7 @@ end
 
 # from which we initialize
 
-mapper2 = BasinMapFeaturizeGroup(ds, featurizer; Δt = 0.1)
+bmap_fg = BasinMapFeaturizeGroup(ds, featurizer; Δt = 0.1)
 
 # [`BasinMapFeaturizeGroup`](@ref) allows for a third input, which is a
 # "grouping configuration", that dictates how features will be grouped into
@@ -271,23 +271,23 @@ mapper2 = BasinMapFeaturizeGroup(ds, featurizer; Δt = 0.1)
 # a trajectory `A` given to the `featurizer` function. Because one of the two attractors
 # is chaotic, we need denser sampling time than the default.
 
-# We can use `mapper2` exactly as `bmap`:
+# We can use `bmap_fg` exactly as `bmap`:
 
-fs2 = basins_fractions(mapper2, sampler)
+fs2 = basins_fractions(bmap_fg, sampler)
 
-attractors2 = extract_attractors(mapper2)
+attractors_fg = extract_attractors(bmap_fg)
 
-plot_attractors(attractors2)
+plot_attractors(attractors_fg)
 
 # This basin map also found the attractors, but we should warn you: this basin map is less
 # robust than [`BasinMapRecurrences`](@ref). One of the reasons for this is
 # that [`BasinMapFeaturizeGroup`](@ref) is not auto-terminating. For example, if we do not
 # have enough transient integration time, the two attractors will get confused into one:
 
-mapper3 = BasinMapFeaturizeGroup(ds, featurizer; Ttr = 10, Δt = 0.1)
-fs3 = basins_fractions(mapper3, sampler)
-attractors3 = extract_attractors(mapper3)
-plot_attractors(attractors3)
+bmap_fg2 = BasinMapFeaturizeGroup(ds, featurizer; Ttr = 10, Δt = 0.1)
+basins_fractions(bmap_fg2, sampler)
+attractors_fg2 = extract_attractors(bmap_fg2)
+plot_attractors(attractors_fg2)
 
 # On the other hand, the downside of [`BasinMapRecurrences`](@ref) is that
 # it can take quite a while to converge for chaotic or high dimensional systems.
@@ -472,9 +472,9 @@ fig = plot_attractors_curves(
 
 # For example, we can probe an elipsoid defined as
 
-params(θ) = [1 => 5 + 0.5cos(θ), 2 => 0.1 + 0.01sin(θ)]
+ellipsoid(θ) = [1 => 5 + 0.5cos(θ), 2 => 0.1 + 0.01sin(θ)]
 θs = range(0, 2π; length = 101)
-pcurve = params.(θs)
+pcurve = ellipsoid.(θs)
 
 # here each component maps the parameter index to its value.
 # We can just give this `pcurve` to the global continuation,

--- a/ext/plotting.jl
+++ b/ext/plotting.jl
@@ -35,7 +35,7 @@ end
 ##########################################################################################
 # Attractors
 ##########################################################################################
-function Attractors.plot_attractors(a; access = SVector(1, 2), kw...)
+function Attractors.plot_attractors(a::Dict; access = SVector(1, 2), kw...)
     fig = Figure()
     AX = length(access) == 2 ? Axis : Axis3
     ax = AX(fig[1, 1])
@@ -44,7 +44,7 @@ function Attractors.plot_attractors(a; access = SVector(1, 2), kw...)
 end
 
 function Attractors.plot_attractors!(
-        ax, attractors;
+        ax, attractors::Dict;
         ukeys = sort(collect(keys(attractors))), # internal argument just for other keywords
         colors = colors_from_keys(ukeys),
         markers = markers_from_keys(ukeys),

--- a/ext/videos.jl
+++ b/ext/videos.jl
@@ -1,13 +1,13 @@
 function Attractors.animate_attractors_continuation(
-        ds::DynamicalSystem, attractors_cont, fractions_cont, prange, pidx; kw...
+        ds::DynamicalSystem, gco::GlobalContinuationOutput; kw...
     )
-    pcurve = [[pidx => p] for p in prange]
-    return animate_attractors_continuation(ds, attractors_cont, fractions_cont, pcurve; prange, kw...)
+    (; attractors, fractions, pcurve) = gco
+    return animate_attractors_continuation(ds, attractors, fractions, pcurve; kw...)
 end
 
 function Attractors.animate_attractors_continuation(
         ds::DynamicalSystem, attractors_cont, fractions_cont, pcurve;
-        savename = "attracont.mp4", access = SVector(1, 2),
+        savename = "globalcont.mp4", access = SVector(1, 2),
         limits = auto_attractor_lims(attractors_cont, access),
         framerate = 4, markersize = 10,
         ukeys = unique_keys(attractors_cont),

--- a/src/continuation/continuation_ascm_generic.jl
+++ b/src/continuation/continuation_ascm_generic.jl
@@ -13,7 +13,8 @@ for more options.
 
 ## Description
 
-This is a general/composable global continuation method based on a 4-step process:
+This is a general and composable global continuation method outlined in our article
+[Datseris2026](@cite) and based on a 4-step process:
 
 1. Seed initial conditions from previously found attractors
 2. Propagate those forwards to "continue" previous attractors
@@ -127,9 +128,10 @@ function global_continuation(
     bmap = ascm.bmap
     prev_attractors = empty(extract_attractors(bmap))
     additional_ics = typeof(current_state(referenced_dynamical_system(bmap)))[]
-    # At each parameter `p`, a dictionary mapping attractor ID to fraction is created.
-    attractors_cont = Dict[]
-    fractions_cont = Dict[]
+    # setup output containers
+    attractors_cont = typeof(prev_attractors)[]
+    quantifiers_cont = []
+    other_cont = Dict{String, Any}()
     # Continue loop over all remaining parameters
     for (i, p) in enumerate(pcurve)
         set_parameters!(referenced_dynamical_system(bmap), p)
@@ -165,17 +167,36 @@ function global_continuation(
         end
         # All the computations are done, and now we just store the result(s)
         # we don't match attractors here, this happens directly at the end.
-        push!(fractions_cont, fs)
+        if bmap isa StabilityQuantifiersAccumulator
+            quantifiers = finalize_accumulator(bmap)
+        else
+            quantifiers = fs
+        end
+        push!(quantifiers_cont, quantifiers)
         # deepcopy is important here as attractor container always referrenced
         prev_attractors = deepcopy(extract_attractors(bmap))
         push!(attractors_cont, prev_attractors)
+        # any extras that need to be updated can be done so here:
+        add_extra_continuation_info!(other_cont, sampler)
         # update progress bar
         showvalues = i < length(pcurve) ? [("pcurve index", i + 1)] : []
         ProgressMeter.next!(progress; showvalues)
     end
+    # we now do the matching pass
     rmaps = match_sequentially!(
         attractors_cont, ascm.matcher; pcurve, ds = referenced_dynamical_system(bmap)
     )
+    # and finally match the rest of the tracked quantities, as well as transform
+    # them to the agreed output
+    fractions, quantifiers = match_and_generate_output(bmap, quantifiers_cont, rmaps)
+    out = GlobalContinuationOutput(attractors, fractions, quantifiers, other_cont)
+    return out
+end
+
+# This function has a generic form that just matches fractions, and a more technical
+# form that matches various quantifiers and is taken care off by the accumulator
+function match_and_generate_output(bmap, quantifiers_cont, rmaps)
+    fractions_cont = quantifiers_cont
     match_sequentially!(fractions_cont, rmaps)
-    return fractions_cont, attractors_cont
+    return fractions_cont, Dict{String, Vector}()
 end

--- a/src/continuation/continuation_ascm_generic.jl
+++ b/src/continuation/continuation_ascm_generic.jl
@@ -189,14 +189,14 @@ function global_continuation(
     # and finally match the rest of the tracked quantities, as well as transform
     # them to the agreed output
     fractions, quantifiers = match_and_generate_output(bmap, quantifiers_cont, rmaps)
-    out = GlobalContinuationOutput(attractors, fractions, quantifiers, other_cont)
+    out = GlobalContinuationOutput(attractors_cont, fractions, quantifiers, other_cont)
     return out
 end
 
 # This function has a generic form that just matches fractions, and a more technical
 # form that matches various quantifiers and is taken care off by the accumulator
 function match_and_generate_output(bmap, quantifiers_cont, rmaps)
-    fractions_cont = quantifiers_cont
+    fractions_cont = Dict{Int, Float64}.(quantifiers_cont)
     match_sequentially!(fractions_cont, rmaps)
     return fractions_cont, Dict{String, Vector}()
 end

--- a/src/continuation/continuation_ascm_generic.jl
+++ b/src/continuation/continuation_ascm_generic.jl
@@ -189,7 +189,7 @@ function global_continuation(
     # and finally match the rest of the tracked quantities, as well as transform
     # them to the agreed output
     fractions, quantifiers = match_and_generate_output(bmap, quantifiers_cont, rmaps)
-    out = GlobalContinuationOutput(attractors_cont, fractions, quantifiers, other_cont)
+    out = GlobalContinuationOutput(attractors_cont, fractions, quantifiers, other_cont, pcurve)
     return out
 end
 

--- a/src/continuation/continuation_grouping.jl
+++ b/src/continuation/continuation_grouping.jl
@@ -83,13 +83,13 @@ function _get_features_pcurve(bmap::BasinMapFeaturizeGroup, sampler, n, spp, pcu
     )
     # Extract the first possible feature to initialize the features container
     u0s = generate_ics(sampler)
-    set_parameters!(bmap.ds, first(pcurve))
+    set_parameters!(referenced_dynamical_system(bmap), first(pcurve))
     current_features = extract_features(bmap, u0s; show_progress, N = length(sampler))
     features = Vector{typeof(current_features[1])}(undef, n * spp)
     features[1:spp] .= current_features
     # Collect features across parameter axis
     for i in 2:length(pcurve)
-        set_parameters!(bmap.ds, pcurve[i])
+        set_parameters!(referenced_dynamical_system(bmap), pcurve[i])
         u0s = generate_ics(sampler)
         current_features = extract_features(bmap, u0s; show_progress, N = length(sampler))
         features[((i - 1) * spp + 1):(i * spp)] .= current_features

--- a/src/continuation/continuation_grouping.jl
+++ b/src/continuation/continuation_grouping.jl
@@ -2,14 +2,15 @@ export FeaturizeGroupAcrossParameter
 import ProgressMeter
 import Mmap
 
-struct FeaturizeGroupAcrossParameter{A <: BasinMapFeaturizeGroup, E} <: GlobalContinuationAlgorithm
-    bmap::A
+struct FeaturizeGroupAcrossParameter{B <: BasinMapFeaturizeGroup, E} <: GlobalContinuationAlgorithm
+    bmap::B
     info_extraction::E
+    store_features::Bool
 end
 
 """
     FeaturizeGroupAcrossParameter <: GlobalContinuationAlgorithm
-    FeaturizeGroupAcrossParameter(bmap::BasinMapFeaturizeGroup [, info_extraction])
+    FeaturizeGroupAcrossParameter(bmap::BasinMapFeaturizeGroup [, info_extraction]; kw...)
 
 A method for [`global_continuation`](@ref) that featurizes and groups
 trajectories across the whole parameter axis to establish a continuation of the groups.
@@ -19,8 +20,11 @@ trajectories across the whole parameter axis to establish a continuation of the 
 By default, the centroid of the cluster is used as its description.
 This output becomes the `attractors` representation in [`GlobalContinuationOutput`](@ref).
 
-This method adds some information into the `other` field of `GlobalContinuationOutput`:
-- `"`
+If the keyword `store_features` is `true` (default), then
+this method adds some information into the `other` field of `GlobalContinuationOutput`:
+- `"features"` contains the features per parameter step
+- `"labels"` contains their corresponding labels (both containers are sorted)
+which allows subsequent analysis of the grouped features.
 
 ## Description
 
@@ -36,8 +40,8 @@ to each parameter value they came from.
 This continuation method is based on, but strongly generalizes, the approaches
 in the papers [Gelbrecht2020](@cite) and [Stender2021](@cite).
 """
-function FeaturizeGroupAcrossParameter(bmap::BasinMapFeaturizeGroup)
-    return FeaturizeGroupAcrossParameter(bmap, mean_across_features)
+function FeaturizeGroupAcrossParameter(bmap::BasinMapFeaturizeGroup; store_features = true)
+    return FeaturizeGroupAcrossParameter(bmap, mean_across_features, store_features)
 end
 
 function mean_across_features(fs)
@@ -60,10 +64,17 @@ function global_continuation(
     spp, n = length(sampler), length(pcurve)
     features = _get_features_pcurve(bmap, sampler, n, spp, pcurve, show_progress)
     labels = group_features(features, bmap.group_config)
-    fractions_cont, attractors_cont = label_fractions_across_parameter(
+    fractions_cont, attractors_cont, feat_cont, label_cont = label_fractions_across_parameter(
         labels, features, n, spp, info_extraction
     )
-    return fractions_cont, attractors_cont
+    # wrap output into the designated type:
+    if continuation.store_features
+        other = Dict("features" => feat_cont, "labels" => label_cont)
+    else
+        other = Dict{String, Nothing}()
+    end
+    out = GlobalContinuationOutput(attractors_cont, fractions_cont, Dict{String,Vector}(), other, pcurve)
+    return out
 end
 
 function _get_features_pcurve(bmap::BasinMapFeaturizeGroup, sampler, n, spp, pcurve, show_progress)
@@ -92,12 +103,16 @@ function label_fractions_across_parameter(labels, features, n, spp, info_extract
     fractions_cont = Vector{Dict{Int, Float64}}(undef, n)
     dummy_info = info_extraction([first(features)])
     attractors_cont = Vector{Dict{Int, typeof(dummy_info)}}(undef, n)
+    features_cont = []
+    labels_cont = []
     for i in 1:n
         # Here we know which indices correspond to which parameter value
         # because they are sequentially increased every `spp`
         # (steps per parameter)
         current_labels = view(labels, ((i - 1) * spp + 1):(i * spp))
         current_features = view(features, ((i - 1) * spp + 1):(i * spp))
+        push!(labels_cont, current_labels)
+        push!(features_cont, current_features)
         current_ids = unique(current_labels)
         # getting fractions is easy; use API function that takes in arrays
         fractions_cont[i] = basins_fractions(current_labels, current_ids)
@@ -107,5 +122,5 @@ function label_fractions_across_parameter(labels, features, n, spp, info_extract
                 ) for id in current_ids
         )
     end
-    return fractions_cont, attractors_cont
+    return fractions_cont, attractors_cont, features_cont, labels_cont
 end

--- a/src/continuation/continuation_grouping.jl
+++ b/src/continuation/continuation_grouping.jl
@@ -5,14 +5,25 @@ import Mmap
 struct FeaturizeGroupAcrossParameter{A <: BasinMapFeaturizeGroup, E} <: GlobalContinuationAlgorithm
     bmap::A
     info_extraction::E
-    par_weight::Float64
 end
 
 """
     FeaturizeGroupAcrossParameter <: GlobalContinuationAlgorithm
-    FeaturizeGroupAcrossParameter(bmap::BasinMapFeaturizeGroup; kwargs...)
+    FeaturizeGroupAcrossParameter(bmap::BasinMapFeaturizeGroup [, info_extraction])
 
-A method for [`global_continuation`](@ref).
+A method for [`global_continuation`](@ref) that featurizes and groups
+trajectories across the whole parameter axis to establish a continuation of the groups.
+
+`info_extraction::Function` is a function that takes as an input a vector of feature-vectors
+(corresponding to a cluster) and returns a description of the cluster.
+By default, the centroid of the cluster is used as its description.
+This output becomes the `attractors` representation in [`GlobalContinuationOutput`](@ref).
+
+This method adds some information into the `other` field of `GlobalContinuationOutput`:
+- `"`
+
+## Description
+
 It uses the featurizing approach discussed in [`BasinMapFeaturizeGroup`](@ref)
 and hence requires an instance of that bmap as an input.
 When used in [`global_continuation`](@ref), features are extracted
@@ -24,22 +35,9 @@ to each parameter value they came from.
 
 This continuation method is based on, but strongly generalizes, the approaches
 in the papers [Gelbrecht2020](@cite) and [Stender2021](@cite).
-
-## Keyword arguments
-
-- `info_extraction::Function` a function that takes as an input a vector of feature-vectors
-  (corresponding to a cluster) and returns a description of the cluster.
-  By default, the centroid of the cluster is used.
-  This is what the `attractors_cont` contains in the return of `global_continuation`.
 """
-function FeaturizeGroupAcrossParameter(
-        bmap::BasinMapFeaturizeGroup;
-        info_extraction = mean_across_features,
-        par_weight = 0.0,
-    )
-    return FeaturizeGroupAcrossParameter(
-        bmap, info_extraction, par_weight
-    )
+function FeaturizeGroupAcrossParameter(bmap::BasinMapFeaturizeGroup)
+    return FeaturizeGroupAcrossParameter(bmap, mean_across_features)
 end
 
 function mean_across_features(fs)
@@ -54,26 +52,17 @@ function mean_across_features(fs)
 end
 
 function global_continuation(
-        continuation::FeaturizeGroupAcrossParameter, pcurve::Vector, ics::InitialConditionSampler;
+        continuation::FeaturizeGroupAcrossParameter, pcurve::Vector, sampler::InitialConditionSampler;
         show_progress = true,
     )
-    (; bmap, info_extraction, par_weight) = continuation
-    spp, n = length(ics), length(pcurve)
-    features = _get_features_pcurve(bmap, ics, n, spp, pcurve, show_progress)
-
-    # This is a special clause for implementing the MCBB algorithm (weighting
-    # also by parameter value, i.e., making the parameter value a feature)
-    # It calls a special `group_features` function that also incorporates the
-    # parameter value (see below). Otherwise, we call normal `group_features`.
-    # TODO: We have deprecated this special clause. In the next version we need to cleanup
-    # the source code and remove the `par_weight` and its special treatment in `group_features`.
-    if bmap.group_config isa GroupViaClustering && par_weight ≠ 0
-        labels = group_features(features, bmap.group_config; par_weight, plength = n, spp)
-    else
-        labels = group_features(features, bmap.group_config)
-    end
-    fractions_cont, attractors_cont =
-        label_fractions_across_parameter(labels, 1features, n, spp, info_extraction)
+    (; bmap, info_extraction) = continuation
+    # spp means 'samples per parameter'
+    spp, n = length(sampler), length(pcurve)
+    features = _get_features_pcurve(bmap, sampler, n, spp, pcurve, show_progress)
+    labels = group_features(features, bmap.group_config)
+    fractions_cont, attractors_cont = label_fractions_across_parameter(
+        labels, features, n, spp, info_extraction
+    )
     return fractions_cont, attractors_cont
 end
 

--- a/src/continuation/continuation_stability_quantifiers.jl
+++ b/src/continuation/continuation_stability_quantifiers.jl
@@ -25,13 +25,15 @@ end
 
 """
     stability_quantifiers_along_continuation(
-        ds::DynamicalSystem, attractors_cont, pcurve, ics;
+        ds::DynamicalSystem, attractors_cont, pcurve, sampler;
         kw...
     )
 
 Perform a global continuation of all stability quantifiers estimated by
 [`StabilityQuantifiersAccumulator`](@ref) using the found attractors of
 a previous call to [`global_continuation`](@ref) using the `ds`.
+The inputs `pcurve, sampler` are the same as in [`global_continuation`](@ref)
+(i.e., a vector and an `InitialConditionSampler`).
 
 This method is special because it always creates a [`BasinMapProximity`](@ref)
 for the attractors at a given point along the global continuation,
@@ -55,8 +57,6 @@ There are two reasons to use this method:
     sampled-basin entropy quantifiers.
 - `n_basin_entropy = 100`: given to [`StabilityQuantifiersAccumulator`](@ref) as the number
     of nearest neighbors used by sampled-basin entropy quantifiers.
-- `samples_per_parameter = 1000`: how many samples to use when estimating stability quantifiers
-  via [`StabilityQuantifiersAccumulator`](@ref). Ignored when `ics` is not a function.
 
 ## Aggregating attractors
 
@@ -71,13 +71,12 @@ function stability_quantifiers_along_continuation(
         ds::DynamicalSystem,
         attractors_cont,
         pcurve,
-        ics;
+        sampler;
         ε = nothing,
         weighting_distribution = EverywhereUniform(),
         finite_time = 1.0,
         basin_entropy = true,
         n_basin_entropy = 100,
-        samples_per_parameter = 1000,
         distance = Centroid(),
         proximity_mapper_options = NamedTuple(),
         show_progress = true
@@ -85,7 +84,17 @@ function stability_quantifiers_along_continuation(
     progress = ProgressMeter.Progress(
         length(pcurve); desc = "Continuing accumulator quantifiers:", enabled = show_progress
     )
-    N = samples_per_parameter
+
+    # Deprecation: remove this at later version.
+    if !(sampler isa InitialConditionSampler)
+        @warn "You must now pass a subtype of `InitialConditionSampler` explicitly."
+        if sampler isa AbstractVector
+            sampler = PrescribedICs(sampler)
+        else
+            sampler = RandomICSampler(sampler, 1000)
+        end
+    end
+
     quantifiers_cont = []
     quantifier_names = nothing
     for (i, p) in enumerate(pcurve)
@@ -135,12 +144,8 @@ function stability_quantifiers_along_continuation(
             n_basin_entropy = n_basin_entropy,
         )
 
-        if ics isa PerParameterICs
-            pics = ics.generator(p, N)
-        else
-            pics = ics
-        end
-        basins_fractions(accumulator, pics; N, show_progress = false)
+        pics = generate_ics(sampler, p)
+        basins_fractions(accumulator, pics; N = length(sampler), show_progress = false)
         quantifiers = finalize_accumulator(accumulator)
         if quantifier_names === nothing
             quantifier_names = collect(keys(quantifiers))

--- a/src/continuation/continuation_stability_quantifiers.jl
+++ b/src/continuation/continuation_stability_quantifiers.jl
@@ -71,6 +71,27 @@ function accumulator_continuation_output(quantifiers_cont, rmaps)
     return transposed
 end
 
+function match_and_generate_output(bmap::StabilityQuantifiersAccumulator, quantifiers_cont, rmaps)
+    # match
+    for (i, rmap) in enumerate(rmaps)
+        for dict in values(quantifiers_cont[i + 1])
+            swap_dict_keys!(dict, rmap)
+        end
+    end
+    # "transpose" (i.e., swap nesting order)
+    transposed = Dict{String, Vector{Dict{Int64, Any}}}()
+    for quantifier in quantifiers_cont[1]
+        quantifier_name = quantifier[1]
+        transposed[quantifier_name] = Vector{Dict{Int64, Any}}()
+    end
+    for quantifiers in quantifiers_cont
+        for (quantifier_name, quantifier_dict) in quantifiers
+            push!(transposed[quantifier_name], quantifier_dict)
+        end
+    end
+    return transposed["basin_fraction"], transposed
+end
+
 
 # make sure to allow the possiblity that the proximity options can also be
 # vectors of same length as `pcurve`; Same for the distributions

--- a/src/continuation/continuation_stability_quantifiers.jl
+++ b/src/continuation/continuation_stability_quantifiers.jl
@@ -1,76 +1,6 @@
 export stability_quantifiers_along_continuation
 
-# This function is practically identical with the original one in
-# `continuation_ascm_generic.jl`; only small differences exist
-function global_continuation(
-        ascm::AttractorSeedContinueMatch{<:StabilityQuantifiersAccumulator}, pcurve, ics;
-        samples_per_parameter = 100, show_progress = true,
-    )
-    N = samples_per_parameter
-    progress = ProgressMeter.Progress(
-        length(pcurve);
-        desc = "Global continuation (accumulator):", PMKWARGS..., enabled = show_progress
-    )
-    bmap = ascm.bmap
-    prev_attractors = empty(extract_attractors(bmap))
-    additional_ics = typeof(current_state(referenced_dynamical_system(bmap)))[]
-    attractors_cont = Dict[]
-    # difference one: this isn't fractions
-    quantifiers_cont = []
-    for (i, p) in enumerate(pcurve)
-        set_parameters!(referenced_dynamical_system(bmap), p)
-        reset_mapper!(bmap)
-        empty!(additional_ics)
-        for att in values(prev_attractors)
-            for u0 in ascm.seeding(att)
-                push!(additional_ics, u0)
-            end
-        end
-        if ics isa PerParameterInitialConditions
-            pics = ics.generator(p, N)
-        else
-            pics = ics
-        end
-        # difference two: we don't care about the return of basins_fractions
-        # as initial condition mapping is accumulated anyways
-        basins_fractions(bmap, pics; N, additional_ics, show_progress, offset = 2)
-        quantifiers = finalize_accumulator(bmap)
-        prev_attractors = deepcopy(extract_attractors(bmap))
-        push!(attractors_cont, prev_attractors)
-        push!(quantifiers_cont, quantifiers)
-        showvalues = i < length(pcurve) ? [("pcurve index", i + 1)] : []
-        ProgressMeter.next!(progress; showvalues)
-    end
-
-    rmaps = match_sequentially!(
-        attractors_cont, ascm.matcher; pcurve, ds = referenced_dynamical_system(bmap)
-    )
-    # and difference four, a bit more involved matching for quantifiers:
-    transposed = accumulator_continuation_output(quantifiers_cont, rmaps)
-    return transposed, attractors_cont
-end
-
-function accumulator_continuation_output(quantifiers_cont, rmaps)
-    # match
-    for (i, rmap) in enumerate(rmaps)
-        for dict in values(quantifiers_cont[i + 1])
-            swap_dict_keys!(dict, rmap)
-        end
-    end
-    # "transpose" (i.e., swap nesting order)
-    transposed = Dict{String, Vector{Dict{Int64, Any}}}()
-    for quantifier in quantifiers_cont[1]
-        quantifier_name = quantifier[1]
-        transposed[quantifier_name] = Vector{Dict{Int64, Any}}()
-    end
-    for quantifiers in quantifiers_cont
-        for (quantifier_name, quantifier_dict) in quantifiers
-            push!(transposed[quantifier_name], quantifier_dict)
-        end
-    end
-    return transposed
-end
-
+# this fuction is called in `global_continuation` when the bmap is the accumulator
 function match_and_generate_output(bmap::StabilityQuantifiersAccumulator, quantifiers_cont, rmaps)
     # match
     for (i, rmap) in enumerate(rmaps)
@@ -89,12 +19,10 @@ function match_and_generate_output(bmap::StabilityQuantifiersAccumulator, quanti
             push!(transposed[quantifier_name], quantifier_dict)
         end
     end
-    return transposed["basin_fraction"], transposed
+    return Vector{Dict{Int64, Float64}}(transposed["basin_fraction"]), transposed
 end
 
 
-# make sure to allow the possiblity that the proximity options can also be
-# vectors of same length as `pcurve`; Same for the distributions
 """
     stability_quantifiers_along_continuation(
         ds::DynamicalSystem, attractors_cont, pcurve, ics;
@@ -105,15 +33,15 @@ Perform a global continuation of all stability quantifiers estimated by
 [`StabilityQuantifiersAccumulator`](@ref) using the found attractors of
 a previous call to [`global_continuation`](@ref) using the `ds`.
 
-This method is special because it always creates an [`BasinMapProximity`](@ref)
-bmap for the attractors at a given point along the global continuation,
+This method is special because it always creates a [`BasinMapProximity`](@ref)
+for the attractors at a given point along the global continuation,
 and then estimates the stability quantifiers using [`StabilityQuantifiersAccumulator`](@ref)
-and the proximity bmap.
+and the proximity map.
 
 There are two reasons to use this method:
 
 1. You are interested in quantifiers related to the convergence time, which is defined
-   more rirogously and is estimated more accurately for a proximity bmap.
+   more rirogously and is estimated more accurately for a proximity map.
 2. You want more control over the values of `ε, finite_time, weighting_distribution`,
    all of which are allowed to be `Vector`s with the same length as `pcurve`.
    (they can always be functions)
@@ -207,7 +135,7 @@ function stability_quantifiers_along_continuation(
             n_basin_entropy = n_basin_entropy,
         )
 
-        if ics isa PerParameterInitialConditions
+        if ics isa PerParameterICs
             pics = ics.generator(p, N)
         else
             pics = ics

--- a/src/continuation/global_continuation_api.jl
+++ b/src/continuation/global_continuation_api.jl
@@ -45,6 +45,7 @@ struct GlobalContinuationOutput{SSS<:StateSpaceSet, F<:AbstractFloat, V<:Vector,
     quantifiers::Dict{String, V}
     other::Dict{String, A} # TODO: Can this include the extras of accumulation?
 end
+# this type extents `iterate` in deprecated.jl file.
 
 # Internal function for adding info; dispatches on `something`
 function add_extra_continuation_info!(extras::Dict{String,Any}, something)

--- a/src/continuation/global_continuation_api.jl
+++ b/src/continuation/global_continuation_api.jl
@@ -27,7 +27,7 @@ The type of output of [`global_continuation`](@ref). It contains the fields:
   `fractions[i]` is a dictionary mapping basin IDs to their basin fraction
   at the `i`-th parameter combination.
 - `quantifiers::Dict{String, Vector{Dict}}`. Quantifiers of the attractors
-  or their basins that have been (potentially) continued. This entry is typically empty,
+  or their basins that have been (potentially) continued. This entry is empty,
   unless continuation is done with [`StabilityQuantifiersAccumulator`](@ref).
   Then, it is a dictionary mapping strings (names of quantifiers) to vectors of dictionaries.
 - `other::Dict{String, Any}`. Any other information was generated during the continuation,

--- a/src/continuation/global_continuation_api.jl
+++ b/src/continuation/global_continuation_api.jl
@@ -50,13 +50,6 @@ struct GlobalContinuationOutput{SSS, F<:AbstractFloat, V<:Vector, A, P}
 end
 # this type extents `iterate` in deprecated.jl file.
 
-# Generic pretty printing
-function generic_mapper_print(io, bmap)
-    ps = 14
-    println(io, "$(nameof(typeof(bmap)))")
-    println(io, rpad(" system: ", ps), nameof(typeof(referenced_dynamical_system(bmap))))
-    return ps
-end
 function Base.show(io::IO, gco::GlobalContinuationOutput)
     println(io, "GlobalContinuationOutput with fields:")
     println(io, " attractors")

--- a/src/continuation/global_continuation_api.jl
+++ b/src/continuation/global_continuation_api.jl
@@ -32,6 +32,7 @@ The type of output of [`global_continuation`](@ref). It contains the fields:
   Then, it is a dictionary mapping strings (names of quantifiers) to vectors of dictionaries.
 - `other::Dict{String, Any}`. Any other information was generated during the continuation,
   that may relate to the sampling strategy, featurizing, or other.
+- `pcurve::Vector{<:Dict}`. The parameter curve the continuation continued over.
 
 The various algorithms used in global continuation inform in their documentation strings
 about additional information added to this output.
@@ -39,11 +40,12 @@ about additional information added to this output.
 See the function [`continuation_series`](@ref) if you wish to transform the output(s)
 to an alternative format.
 """
-struct GlobalContinuationOutput{SSS<:StateSpaceSet, F<:AbstractFloat, V<:Vector, A}
+struct GlobalContinuationOutput{SSS<:StateSpaceSet, F<:AbstractFloat, V<:Vector, A, P}
     attractors::Vector{Dict{Int, SSS}}
     fractions::Vector{Dict{Int, F}}
     quantifiers::Dict{String, V}
     other::Dict{String, A} # TODO: Can this include the extras of accumulation?
+    pcurve::Vector{P}
 end
 # this type extents `iterate` in deprecated.jl file.
 

--- a/src/continuation/global_continuation_api.jl
+++ b/src/continuation/global_continuation_api.jl
@@ -1,4 +1,6 @@
-export global_continuation, GlobalContinuationAlgorithm, continuation_series, stability_quantifiers_along_continuation
+export global_continuation, GlobalContinuationAlgorithm, continuation_series
+export GlobalContinuationOutput
+
 include("sampler_api.jl")
 
 """
@@ -12,6 +14,37 @@ across a parameter range.
 See [`global_continuation`](@ref) for more.
 """
 abstract type GlobalContinuationAlgorithm end
+
+"""
+    GlobalContinuationOutput
+
+The type of output of [`global_continuation`](@ref). It contains the fields:
+
+- `attractors::Vector{Dict{Int, SSSet}}`. The continued and matched attractors.
+  `attractors[i]` is a dictionary mapping basin ID to its
+  attractor set at the `i`-th parameter combination.
+- `fractions::Vector{Dict{Int, Float64}}`. The fractions of basins of attraction.
+  `fractions[i]` is a dictionary mapping basin IDs to their basin fraction
+  at the `i`-th parameter combination.
+- `quantifiers::Dict{String, Vector{Dict}}`. Any other quantifiers of the attractors
+  or their basins that have been potentially continued. This entry is typically empty,
+  unless continuation is done with [`StabilityQuantifiersAccumulator`](@ref).
+  Then, it is a dictionary mapping strings (names of quantifiers) to vectors of dictionaries.
+- `extras::Dict{String, X}`. Anything extra that has been tracked during the continuation,
+  such as user-specified quantities or information regarding the sampling strategy.
+
+The various algorithms used in global continuation inform in their documentation strings
+about additional information added to this output.
+
+See the function [`continuation_series`](@ref) if you wish to transform the output(s)
+to an alternative format.
+"""
+struct GlobalContinuationOutput{SSS<:StateSpaceSet, F<:AbstractFloat, DE<:Dict}
+    attractors::Vector{Dict{Int, SSS}}
+    fractions::Vector{Dict{Int, F}}
+    quantifiers::Dict{String, Vector{DQ}}
+    extras::Dict{String, Vector{DE}}
+end
 
 """
     global_continuation(gca::GlobalContinuationAlgorithm, pcurve, icsampler; kwargs...)
@@ -31,20 +64,11 @@ This defines an arbitrary curve in the parameter space of the dynamical system.
 `icsampler` is a subtype of [`InitialConditionSampler`](@ref) and provides instructions
 for how to sample initial conditions to explore the state space during the continuation.
 
-Return:
+Return an instance of [`GlobalContinuationOutput`](@ref) that contains the continued
+attractors, their basins fractions, and any other additional information.
 
-1. `fractions_cont::Vector{Dict{Int, Float64}}`. The fractions of basins of attraction.
-   `fractions_cont[i]` is a dictionary mapping basin IDs to their basin fraction
-   at the `i`-th parameter combination.
-   -  This output is different if you are using [`StabilityQuantifiersAccumulator`](@ref)
-      in combination with [`AttractorSeedContinueMatch`](@ref). See the docstring
-      of [`StabilityQuantifiersAccumulator`](@ref) for more details.
-2. `attractors_cont::Vector{Dict{Int, SSSet}}`. The continued attractors.
-   `attractors_cont[i]` is a dictionary mapping basin ID to its
-   attractor set at the `i`-th parameter combination.
 
-See the function [`continuation_series`](@ref) if you wish to transform the output(s)
-to an alternative format. There is no difference between single or multi parameter
+There is no difference between single or multi parameter
 global continuation. Use [`hilbert_pcurve`](@ref) to cover multiparameter spaces.
 
 ## Keyword arguments
@@ -62,9 +86,9 @@ arguments that control how to continue/track/match attractors across a parameter
 are given when creating `gca`.
 
 The basin properties and the attractors (or some representation of them) are continued
-across the parameter curve, whose elements are simply given to `DynamicalSystems.set_parameters!`
-to update system parameters. This is fundamentally different to local (traditional) continuation,
-see the online documentation or our article for details.
+across the parameter curve, whose elements are given to `DynamicalSystems.set_parameters!`
+to update system parameters. Thus, global continuation operates on a prescribed parameter
+curve.
 """
 function global_continuation end
 

--- a/src/continuation/global_continuation_api.jl
+++ b/src/continuation/global_continuation_api.jl
@@ -50,6 +50,23 @@ struct GlobalContinuationOutput{SSS, F<:AbstractFloat, V<:Vector, A, P}
 end
 # this type extents `iterate` in deprecated.jl file.
 
+# Generic pretty printing
+function generic_mapper_print(io, bmap)
+    ps = 14
+    println(io, "$(nameof(typeof(bmap)))")
+    println(io, rpad(" system: ", ps), nameof(typeof(referenced_dynamical_system(bmap))))
+    return ps
+end
+function Base.show(io::IO, gco::GlobalContinuationOutput)
+    println(io, "GlobalContinuationOutput with fields:")
+    println(io, " attractors")
+    println(io, " fractions")
+    println(io, " quantifiers")
+    println(io, " other")
+    println(io, " pcurve")
+end
+
+
 # Internal function for adding info; dispatches on `something`
 function add_extra_continuation_info!(extras::Dict{String,Any}, something)
     return nothing

--- a/src/continuation/global_continuation_api.jl
+++ b/src/continuation/global_continuation_api.jl
@@ -39,10 +39,10 @@ about additional information added to this output.
 See the function [`continuation_series`](@ref) if you wish to transform the output(s)
 to an alternative format.
 """
-struct GlobalContinuationOutput{SSS<:StateSpaceSet, D<:Dict, A}
+struct GlobalContinuationOutput{SSS<:StateSpaceSet, F<:AbstractFloat, V<:Vector, A}
     attractors::Vector{Dict{Int, SSS}}
     fractions::Vector{Dict{Int, F}}
-    quantifiers::Dict{String, Vector{D}}
+    quantifiers::Dict{String, V}
     other::Dict{String, A} # TODO: Can this include the extras of accumulation?
 end
 

--- a/src/continuation/global_continuation_api.jl
+++ b/src/continuation/global_continuation_api.jl
@@ -30,8 +30,9 @@ The type of output of [`global_continuation`](@ref). It contains the fields:
   or their basins that have been (potentially) continued. This entry is empty,
   unless continuation is done with [`StabilityQuantifiersAccumulator`](@ref).
   Then, it is a dictionary mapping strings (names of quantifiers) to vectors of dictionaries.
-- `other::Dict{String, Any}`. Any other information was generated during the continuation,
+- `other::Dict{String, Vector}`. Any other information was generated during the continuation,
   that may relate to the sampling strategy, featurizing, or other.
+  Each quantity's name (string) is mapped to a vector of the same length as `pcurve`.
 - `pcurve::Vector{<:Dict}`. The parameter curve the continuation continued over.
 
 The various algorithms used in global continuation inform in their documentation strings
@@ -40,11 +41,11 @@ about additional information added to this output.
 See the function [`continuation_series`](@ref) if you wish to transform the output(s)
 to an alternative format.
 """
-struct GlobalContinuationOutput{SSS<:StateSpaceSet, F<:AbstractFloat, V<:Vector, A, P}
+struct GlobalContinuationOutput{SSS, F<:AbstractFloat, V<:Vector, A, P}
     attractors::Vector{Dict{Int, SSS}}
     fractions::Vector{Dict{Int, F}}
     quantifiers::Dict{String, V}
-    other::Dict{String, A} # TODO: Can this include the extras of accumulation?
+    other::Dict{String, A}
     pcurve::Vector{P}
 end
 # this type extents `iterate` in deprecated.jl file.

--- a/src/continuation/global_continuation_api.jl
+++ b/src/continuation/global_continuation_api.jl
@@ -26,12 +26,12 @@ The type of output of [`global_continuation`](@ref). It contains the fields:
 - `fractions::Vector{Dict{Int, Float64}}`. The fractions of basins of attraction.
   `fractions[i]` is a dictionary mapping basin IDs to their basin fraction
   at the `i`-th parameter combination.
-- `quantifiers::Dict{String, Vector{Dict}}`. Any other quantifiers of the attractors
-  or their basins that have been potentially continued. This entry is typically empty,
+- `quantifiers::Dict{String, Vector{Dict}}`. Quantifiers of the attractors
+  or their basins that have been (potentially) continued. This entry is typically empty,
   unless continuation is done with [`StabilityQuantifiersAccumulator`](@ref).
   Then, it is a dictionary mapping strings (names of quantifiers) to vectors of dictionaries.
-- `extras::Dict{String, X}`. Anything extra that has been tracked during the continuation,
-  such as user-specified quantities or information regarding the sampling strategy.
+- `other::Dict{String, Any}`. Any other information was generated during the continuation,
+  that may relate to the sampling strategy, featurizing, or other.
 
 The various algorithms used in global continuation inform in their documentation strings
 about additional information added to this output.
@@ -39,11 +39,16 @@ about additional information added to this output.
 See the function [`continuation_series`](@ref) if you wish to transform the output(s)
 to an alternative format.
 """
-struct GlobalContinuationOutput{SSS<:StateSpaceSet, F<:AbstractFloat, DE<:Dict}
+struct GlobalContinuationOutput{SSS<:StateSpaceSet, D<:Dict, A}
     attractors::Vector{Dict{Int, SSS}}
     fractions::Vector{Dict{Int, F}}
-    quantifiers::Dict{String, Vector{DQ}}
-    extras::Dict{String, Vector{DE}}
+    quantifiers::Dict{String, Vector{D}}
+    other::Dict{String, A} # TODO: Can this include the extras of accumulation?
+end
+
+# Internal function for adding info; dispatches on `something`
+function add_extra_continuation_info!(extras::Dict{String,Any}, something)
+    return nothing
 end
 
 """
@@ -66,7 +71,6 @@ for how to sample initial conditions to explore the state space during the conti
 
 Return an instance of [`GlobalContinuationOutput`](@ref) that contains the continued
 attractors, their basins fractions, and any other additional information.
-
 
 There is no difference between single or multi parameter
 global continuation. Use [`hilbert_pcurve`](@ref) to cover multiparameter spaces.

--- a/src/continuation/sampler_api.jl
+++ b/src/continuation/sampler_api.jl
@@ -1,5 +1,5 @@
 export InitialConditionSampler
-export RandomICSampler, PerParameterICs, PerParameterInitialConditions
+export RandomICSampler, PrescribedICs, PerParameterICs
 
 """
     InitialConditionSampler
@@ -8,8 +8,8 @@ Data structure deciding how to sample initial conditions during
 [`global_continuation`](@ref).
 Concerete subtypes are:
 
-- [`RandomICSampler`]
-- [`PrescribedICs`]
+- [`RandomICSampler`](@ref)
+- [`PrescribedICs`](@ref)
 - [`PerParameterICs`](@ref)
 
 `InitialConditionSampler` defines a currently experimental extendable interface
@@ -77,11 +77,11 @@ It inputs the current parameter(s) of a [`global_continuation`](@ref)
 `N` initial conditions.
 The sampler generates overall `N` initial conditions.
 """
-struct PerParameterInitialConditions{F} <: InitialConditionSampler
+struct PerParameterICs{F} <: InitialConditionSampler
     f::F
     N::Int
 end
-generate_ics(p::PerParameterInitialConditions, params, args...) = p.f(params, p.N)
+generate_ics(p::PerParameterICs, params, args...) = p.f(params, p.N)
 
 """
     BayesianUpdateSampler(dense_sampler, sparse_sampler, γ = 0.5) <: InitialConditionSampler

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -49,3 +49,13 @@ function global_continuation(alg::GlobalContinuationAlgorithm, pcurve::Vector, i
     end
     return global_continuation(alg, pcurve, sampler; kw...)
 end
+
+function Base.iterate(gco::GlobalContinuationOutput, state = 1)
+    if state == 1
+        return (gco.fractions, 2)
+    elseif state == 2
+        return (gco.attractors, 3)
+    else
+        return nothing
+    end
+end

--- a/src/mapping/attractor_mapping.jl
+++ b/src/mapping/attractor_mapping.jl
@@ -179,11 +179,7 @@ function basins_fractions_labels(bmap::BasinMap, ics;
         append!(icscol, additional_ics)
         basins_fractions_grouped(bmap, icscol, progress, labels)
     end
-    if fill_labels
-        return ffs, labels
-    else
-        return ffs
-    end
+    return ffs, labels
 end
 
 function basins_fractions_individual(bmap, ics, N, progress, labels, additional_ics)

--- a/src/mapping/attractor_mapping.jl
+++ b/src/mapping/attractor_mapping.jl
@@ -165,7 +165,7 @@ function basins_fractions_labels(bmap::BasinMap, ics;
         N;
         desc = "Running basin map:", PMKWARGS..., offset, enabled = show_progress
     )
-    labels = Vector{Int32}(undef, fill_labels ? N : 0)
+    labels = Vector{Int}(undef, fill_labels ? N : 0)
     ffs = if allows_mapper_u0(bmap)
         basins_fractions_individual(bmap, ics, N, progress, labels, additional_ics)
     else

--- a/src/mapping/grouping/cluster_config.jl
+++ b/src/mapping/grouping/cluster_config.jl
@@ -117,14 +117,7 @@ end
 #####################################################################################
 # API function (group features)
 #####################################################################################
-# The keywords `par_weight, plength, spp` enable the "for-free" implementation of the
-# MCBB algorithm (weighting the distance matrix by parameter value as well).
-# The keyword version of this function is only called in
-# `GroupingAcrossParametersContinuation` and is not part of public API!
-function group_features(
-        features, config::GroupViaClustering;
-        par_weight::Real = 0, plength::Int = 1, spp::Int = 1,
-    )
+function group_features(features, config::GroupViaClustering)
     nfeats = length(features); dimfeats = length(features[1])
     if dimfeats ≥ nfeats
         throw(
@@ -143,15 +136,12 @@ function group_features(
     if iszero(ϵ_optimal) # if this is deduced as zero, all features overlap exactly
         return fill(1, length(features))
     end
-    distances = _distance_matrix(features, config; par_weight, plength, spp)
+    distances = _distance_matrix(features, config)
     labels = _cluster_distances_into_labels(distances, ϵ_optimal, config.min_neighbors)
     return labels
 end
 
-function _distance_matrix(
-        features, config::GroupViaClustering;
-        par_weight::Real = 0, plength::Int = 1, spp::Int = 1
-    )
+function _distance_matrix(features, config::GroupViaClustering)
     metric = config.clust_distance_metric
     L = length(features)
     if config.use_mmap
@@ -168,21 +158,6 @@ function _distance_matrix(
             @inbounds for j in i:length(features)
                 v = metric(features[i], features[j])
                 dists[i, j] = dists[j, i] = v # utilize symmetry
-            end
-        end
-    end
-
-    if par_weight ≠ 0 # weight distance matrix by parameter value
-        par_vector = kron(range(0, 1, plength), ones(spp))
-        length(par_vector) ≠ size(dists, 1) && error("Feature size doesn't match.")
-        @inbounds for k in eachindex(par_vector)
-            # We can optimize the loop here due to symmetry of the metric.
-            # Instead of going over all `j` we go over `(k+1)` to end,
-            # and also add value to transpose. (also assume that if j=k, distance is 0)
-            for j in (k + 1):size(dists, 1)
-                pdist = par_weight * abs(par_vector[k] - par_vector[j])
-                dists[k, j] += pdist
-                dists[j, k] += pdist
             end
         end
     end

--- a/src/nonlocal/stability_quantifiers_accumulator.jl
+++ b/src/nonlocal/stability_quantifiers_accumulator.jl
@@ -16,7 +16,7 @@ way possible. `bmap` is any instance of a [`BasinMap`](@ref),
 although for [`BasinMapFeaturizeGroup`](@ref) the convergence times won't make sense.
 
 The accummulator records several quantifiers of stability (or resilience) defined
-in [Morr2026](@cite), and a few more derived after the original publication,
+in [Morr2026](@cite), and a few more added after the publication,
 including the intermingledness of basins of attraction [Datseris2026Intermingled](@cite), see list below.
 However, it also allows computing any additional user-defined quantifier that is
 a function of the attractors and/or their basins of attraction via the `extras`
@@ -36,13 +36,9 @@ to work for any `BasinMap`, current or future.
 Since `StabilityQuantifiersAccumulator` is formally an `BasinMap`, it can be
 used with [`global_continuation`](@ref). Simply give it as a `bmap` input
 to [`AttractorSeedContinueMatch`](@ref) and then call `global_continuation`.
-The only difference now is that `global_continuation` will not return just one
-quantifier of stability (the basin fraction). Rather,
-now the first return argument of `global_continuation` will be a
-`quantifiers_cont`, a dictionary mapping stability quantifiers (strings)
-to vectors of dictionaries. Each vector of dictionaries is similar to `fractions_cont`
-of the typical [`global_continuation`](@ref): a vector of dictionaries mapping attractor IDs
-to the corresponding nonlocal stability quantifiers.
+Then, the field `.quantifiers` of [`GlobalContinuationOutput`](@ref) will be
+filled with all the quantifiers estimated by the accumulator at each parameter.
+These will also be matched just like the attractors and their fractions are matched.
 
 Use [`stability_quantifiers_along_continuation`](@ref) for continuation of stability  quantifiers computed
 on the basis of an `BasinMapProximity` bmap from already found attractors.

--- a/src/nonlocal/stability_quantifiers_accumulator.jl
+++ b/src/nonlocal/stability_quantifiers_accumulator.jl
@@ -541,7 +541,7 @@ end
 function basins_fractions_grouped(accumulator::StabilityQuantifiersAccumulator, ics, progress::Progress, labels)
     # note that ics is always collected into vector, cascaded by `basins_fraction`.
     # Here we'll call the same function with the stored bmap, cheating the system
-    fs, _labels = basins_fractions(accumulator.bmap, ics; show_progress = progress.core.enabled)
+    fs, _labels = basins_fractions_labels(accumulator.bmap, ics; show_progress = progress.core.enabled)
     if !isempty(labels)
         labels .= @view(_labels[1:length(labels)])
     end

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -68,21 +68,19 @@ export shaded_basins_heatmap, shaded_basins_heatmap!
 ##########################################################################################
 """
     animate_attractors_continuation(
-        ds::DynamicalSystem, attractors_cont, fractions_cont, pcurve; kw...
+        ds::DynamicalSystem, gco::GlobalContinuationOutput; kw...
     )
 
 Animate how the found system attractors and their corresponding basin fractions
-change as the system parameter is increased. This function combines the input
+change along a [`global_continuation`](@ref). This function combines the input
 and output of the [`global_continuation`](@ref) function into a video output.
 
 The input dynamical system `ds` is used to evolve initial conditions sampled from the
 found attractors, so that the attractors are better visualized.
-`attractors_cont, fractions_cont` are the output of [`global_continuation`](@ref)
-while `ds, pcurve` are the input to [`global_continuation`](@ref).
 
 ## Keyword arguments
 
-- `savename = "attracont.mp4"`: name of video output file.
+- `savename = "globalcont.mp4"`: name of video output file.
 - `framerate = 4`: framerate of video output.
 - `Δt, T`: propagated to `trajectory` for evolving an initial condition sampled
   from an attractor.

--- a/test/continuation/grouping_continuation.jl
+++ b/test/continuation/grouping_continuation.jl
@@ -36,10 +36,11 @@ using Random
     featurizer(a, t) = a[end]
     clusterspecs = Attractors.GroupViaClustering(optimal_radius_method = "silhouettes", max_used_features = 200)
     bmap = Attractors.BasinMapFeaturizeGroup(ds, featurizer, clusterspecs; T = 20, threaded = false)
-    gap = FeaturizeGroupAcrossParameter(bmap; par_weight = 0.0)
-    fractions_cont, attractors_cont = global_continuation(
+    gap = FeaturizeGroupAcrossParameter(bmap)
+    gco = global_continuation(
         gap, pcurve, sampler; show_progress = false
     )
+    fractions_cont, attractors_cont = gco.fractions, gco.attractors
 
     for (i, r) in enumerate(rrange)
 

--- a/test/continuation/grouping_continuation.jl
+++ b/test/continuation/grouping_continuation.jl
@@ -36,11 +36,14 @@ using Random
     featurizer(a, t) = a[end]
     clusterspecs = Attractors.GroupViaClustering(optimal_radius_method = "silhouettes", max_used_features = 200)
     bmap = Attractors.BasinMapFeaturizeGroup(ds, featurizer, clusterspecs; T = 20, threaded = false)
-    gap = FeaturizeGroupAcrossParameter(bmap)
+    fgap = FeaturizeGroupAcrossParameter(bmap)
     gco = global_continuation(
-        gap, pcurve, sampler; show_progress = false
+        fgap, pcurve, sampler; show_progress = false
     )
     fractions_cont, attractors_cont = gco.fractions, gco.attractors
+
+    @test haskey(gco.other, "features")
+    @test gco.other["features"] |> length == length(pcurve)
 
     for (i, r) in enumerate(rrange)
 
@@ -74,6 +77,14 @@ using Random
         end
         @test sum(values(fs)) ≈ 1
     end
+
+    fgap = FeaturizeGroupAcrossParameter(bmap; store_features = false)
+
+    gco = global_continuation(
+        fgap, pcurve, sampler; show_progress = false
+    )
+    @test !haskey(gco.other, "features")
+
 end
 
 @testset "hilbert cont" begin
@@ -116,10 +127,10 @@ if DO_EXTENSIVE_TESTS
             ds, featurizer, clusterspecs;
             T = 10, Ttr = 2000, threaded = true
         )
-        gap = FeaturizeGroupAcrossParameter(bmap; par_weight = 0.0)
+        fgap = FeaturizeGroupAcrossParameter(bmap; par_weight = 0.0)
         sampler = RandomICSampler(sampler, 100)
         fractions_cont, attractors_cont = global_continuation(
-            gap, pcurve, sampler;
+            fgap, pcurve, sampler;
             show_progress = false
         )
 

--- a/test/continuation/grouping_continuation.jl
+++ b/test/continuation/grouping_continuation.jl
@@ -88,9 +88,9 @@ using Random
 end
 
 @testset "hilbert cont" begin
-    specs = Dict(1 => (5, 6, 2^4), 2 => (0.1, 0.2, 2^4))
+    specs = Dict(1 => (5, 6, 2^2), 2 => (0.1, 0.2, 2^2))
     pcurve = hilbert_pcurve(specs)
-    @test length(pcurve) == 2^8
+    @test length(pcurve) == 2^4
     @test pcurve isa Vector{Dict{Int, Float64}}
 end
 

--- a/test/continuation/matching_attractors.jl
+++ b/test/continuation/matching_attractors.jl
@@ -237,7 +237,8 @@ end
     bmap = BasinMapFeaturizeGroup(ds, featurizer, grouping_config; T = 10, Ttr = 1)
     matcher = MatchByBasinEnclosure(; ε = 0.1)
     assc = AttractorSeedContinueMatch(bmap, matcher)
-    fs_curves, atts_all = global_continuation(assc, rrange, ridx, ics; show_progress = false)
+    gco = global_continuation(assc, rrange, ridx, ics; show_progress = false)
+    fs_curves, atts_all = gco.fractions, gco.attractors
 
     atts_all_endpoint_solution = Dict{Int64, SVector{1, Float64}}[Dict(1 => [0.0]), Dict(1 => [0.0]), Dict(2 => [2.0], 1 => [0.0]), Dict(2 => [2.0], 1 => [0.0]), Dict(2 => [2.0], 3 => [4.0], 1 => [-5.0]), Dict(2 => [2.0], 3 => [4.0], 1 => [-5.0]), Dict(4 => [6.0], 2 => [2.0], 3 => [4.0], 1 => [0.0]), Dict(4 => [6.0], 2 => [2.0], 3 => [4.0], 1 => [0.0]), Dict(5 => [8.0], 4 => [6.0], 2 => [2.0], 3 => [4.0], 1 => [0.0]), Dict(5 => [8.0], 4 => [6.0], 2 => [2.0], 3 => [4.0], 1 => [0.0]), Dict(4 => [6.0], 2 => [2.0], 3 => [4.0], 1 => [0.0]), Dict(4 => [6.0], 2 => [2.0], 3 => [4.0], 1 => [0.0]), Dict(2 => [2.0], 3 => [4.0], 1 => [0.0]), Dict(2 => [2.0], 3 => [4.0], 1 => [0.0]), Dict(2 => [2.0], 1 => [0.0]), Dict(2 => [2.0], 1 => [0.0]), Dict(1 => [0.0]), Dict(1 => [0.0])]
     atts_all_endpoint = [Dict(k => v[end] for (k, v) in atts) for atts in atts_all]

--- a/test/continuation/recurrences_continuation.jl
+++ b/test/continuation/recurrences_continuation.jl
@@ -37,10 +37,12 @@ using Random
     rrange = range(0, 2; length = 20)
     ridx = 1
     rsc = RecurrencesFindAndMatch(bmap; threshold = 0.3)
-    fractions_cont, a = global_continuation(
+    gco = global_continuation(
         rsc, rrange, ridx, sampler;
         show_progress = false, samples_per_parameter = 1000
     )
+
+    fractions_cont, a = gco.fractions, gco.attractors
 
     for (i, r) in enumerate(rrange)
 
@@ -138,10 +140,11 @@ end
     # First, test the normal function of finding attractors
     bmap = BasinMapRecurrences(ds, grid; sparse = true, show_progress = false)
     rsc = RecurrencesFindAndMatch(bmap; threshold = 0.1)
-    fractions_cont, attractors_cont = global_continuation(
+    gco = global_continuation(
         rsc, rrange, ridx, sampler;
         show_progress = false, samples_per_parameter = 1000,
     )
+    fractions_cont, attractors_cont = gco.fractions, gco.attractors
     test_fs(fractions_cont, rrange, [4, 12])
 
     # Then, test aggregating the basin fractions: first group the attractors with
@@ -217,10 +220,11 @@ if DO_EXTENSIVE_TESTS
             bmap;
             threshold = 0.99, distance = distance_function
         )
-        fractions_cont, attractors_cont = global_continuation(
+        gco = global_continuation(
             rsc, ps, pidx, sampler;
             show_progress = false, samples_per_parameter = 100
         )
+        fractions_cont, attractors_cont = gco.fractions, gco.attractors
 
         for (i, p) in enumerate(ps)
             fs = fractions_cont[i]

--- a/test/continuation/recurrences_continuation.jl
+++ b/test/continuation/recurrences_continuation.jl
@@ -35,11 +35,10 @@ using Random
     sampler, = statespace_sampler(grid, 1234)
 
     rrange = range(0, 2; length = 20)
-    ridx = 1
+    pcurve = [Dict(1 => r) for r in rrange]
     rsc = RecurrencesFindAndMatch(bmap; threshold = 0.3)
     gco = global_continuation(
-        rsc, rrange, ridx, sampler;
-        show_progress = false, samples_per_parameter = 1000
+        rsc, pcurve, RandomICSampler(sampler, 1000); show_progress = false,
     )
 
     fractions_cont, a = gco.fractions, gco.attractors
@@ -137,12 +136,12 @@ end
 
     rrange = range(0, 2; length = 21)
     ridx = 1
+    pcurve = [Dict(ridx => r) for r in rrange]
     # First, test the normal function of finding attractors
     bmap = BasinMapRecurrences(ds, grid; sparse = true, show_progress = false)
     rsc = RecurrencesFindAndMatch(bmap; threshold = 0.1)
     gco = global_continuation(
-        rsc, rrange, ridx, sampler;
-        show_progress = false, samples_per_parameter = 1000,
+        rsc, pcurve, RandomICSampler(sampler, 1000); show_progress = false
     )
     fractions_cont, attractors_cont = gco.fractions, gco.attractors
     test_fs(fractions_cont, rrange, [4, 12])

--- a/test/continuation/seed_continue_generic.jl
+++ b/test/continuation/seed_continue_generic.jl
@@ -49,9 +49,10 @@ using Random
     @testset "case: $(i)" for (i, bmap) in enumerate(mappers)
         algo = AttractorSeedContinueMatch(bmap)
         pcurve = [[1 => r, 2 => 1.1] for r in rrange]
-        fractions_cont, a = global_continuation(
+        gco = global_continuation(
             algo, pcurve, sampler; show_progress = false,
         )
+        fractions_cont = gco.fractions
 
         for (i, r) in enumerate(rrange)
             fs = fractions_cont[i]

--- a/test/continuation/seed_continue_generic.jl
+++ b/test/continuation/seed_continue_generic.jl
@@ -111,9 +111,11 @@ end
     gca = AttractorSeedContinueMatch(bmap; seeding = A -> [])
 
     pcurve = [Dict(1 => r) for r in rs]
-    fractions_cont, attractors_cont = global_continuation(
+    gco = global_continuation(
         gca, pcurve, icsgen; show_progress = false
     )
+
+    attractors_cont = gco.attractors
 
     # all times 2 attractors, never the 0.0 attractor
     @test all(A -> length(A) == 2, attractors_cont)

--- a/test/continuation/seed_continue_generic.jl
+++ b/test/continuation/seed_continue_generic.jl
@@ -103,7 +103,7 @@ end
         ics = [SVector(v, w + I) for w in grid[2] for v in grid[1]]
         return ics
     end
-    icsgen = PerParameterInitialConditions(make_ics, 25)
+    icsgen = PerParameterICs(make_ics, 25)
 
     featurizer(A, t) = A[end]
     gconfig = GroupViaPairwiseComparison(threshold = 0.25, rescale_features = false)

--- a/test/mapping/attractor_mapping.jl
+++ b/test/mapping/attractor_mapping.jl
@@ -46,7 +46,7 @@ function test_basins(
         @test sum(values(fs)) ≈ 1 atol = 1.0e-14
 
         # Precise test with known initial conditions
-        fs, labels = basins_fractions(bmap, ics; show_progress = false)
+        fs = basins_fractions(bmap, ics; show_progress = false)
         # @show nameof(typeof(bmap))
         # @show fs
         approx_atts = extract_attractors(bmap)
@@ -59,7 +59,13 @@ function test_basins(
         @test length(found_fs) == length(expected_fs) #number of attractors
         errors = abs.(expected_fs .- found_fs)
         for er in errors
-            @test er .≤ err
+            if !all(er .≤ err)
+                @show er
+                @show err
+                @test false
+            else
+                @test true
+            end
         end
         return if known # also test whether the attractor index is correct
             for k in known_ids
@@ -371,7 +377,7 @@ end
     bmap = BasinMapRecurrences(ds, grid; sparse = false)
     basins, atts = basins_of_attraction(bmap; show_progress = false)
     ics = [ [x, 1.0] for x in range(-3, 3, length = 20)]
-    fractions, labels = basins_fractions(bmap, ics; show_progress = false)
+    fractions = basins_fractions(bmap, ics; show_progress = false)
 
     @test 0 ∉ keys(fractions)
 end

--- a/test/mapping/basins_of_attraction.jl
+++ b/test/mapping/basins_of_attraction.jl
@@ -48,7 +48,7 @@ end
     set_state!(ds, 0.0, 2)
     ics = [Dict(1 => x) for x in xg]
     fs, labels, iterations = convergence_and_basins_fractions(bmap, ics)
-    fs2, labels = basins_fractions(bmap, ics; show_progress = false)
+    fs2 = basins_fractions(bmap, ics; show_progress = false)
 
     for fs in (fs, fs2)
         @test length(fs) == 2

--- a/test/mapping/histogram_grouping.jl
+++ b/test/mapping/histogram_grouping.jl
@@ -32,7 +32,7 @@ expected_fs_raw = Dict(1 => 0.451, -1 => 0.549)
 sampler, _ = statespace_sampler(grid, 12444)
 
 ics = StateSpaceSet([copy(sampler()) for _ in 1:1000])
-fs, = basins_fractions(bmap, ics; show_progress = false)
+fs = basins_fractions(bmap, ics; show_progress = false)
 @test length(keys(fs)) == 2
 @test fs[1] ≈ 0.45 rtol = 1.0e-1
 # the divergent points go to last bin, which is 25 = 5x5

--- a/test/mapping/recurrence.jl
+++ b/test/mapping/recurrence.jl
@@ -50,7 +50,7 @@ if DO_EXTENSIVE_TESTS
             sampler, = statespace_sampler(HRectangle([-0.5, 0], [0.5, 1]), 155)
             ics = StateSpaceSet([copy(sampler()) for i in 1:1000])
 
-            fs, labels = basins_fractions(bmap, ics; show_progress = false)
+            fs = basins_fractions(bmap, ics; show_progress = false)
             num_att = length(fs)
             return num_att
         end

--- a/test/nonlocal/stability_quantifiers_accumulator.jl
+++ b/test/nonlocal/stability_quantifiers_accumulator.jl
@@ -87,7 +87,7 @@ using Random
             Ttr = 0, stop_at_Δt = false, horizon_limit = 1.0e2, consecutive_lost_steps = 10000,
         )
         quantifiers_cont = stability_quantifiers_along_continuation(
-            dynamics, attractors_cont, pcurve, ics_from_grid(grid), ε = 0.1, finite_time = 0.5,
+            dynamics, attractors_cont, pcurve, PrescribedICs(ics_from_grid(grid)); ε = 0.1, finite_time = 0.5,
             proximity_mapper_options = proximity_mapper_options
         )
 
@@ -163,7 +163,7 @@ using Random
         @test cent_step[only(keys(cent_step))] ≈ SVector(0.0)
 
         quantifiers_agg = stability_quantifiers_along_continuation(
-            dynamics, agg_attractors_cont, pcurve, ics_from_grid(grid);
+            dynamics, agg_attractors_cont, pcurve, PrescribedICs(ics_from_grid(grid));
             ε = 0.1, finite_time = 0.5, proximity_mapper_options,
         )
 
@@ -244,8 +244,9 @@ end
         proximity_mapper_options_local = (
             Ttr = 0, stop_at_Δt = false, horizon_limit = 1.0e2, consecutive_lost_steps = 10000,
         )
+        gcsampler = PrescribedICs(ics_from_grid(grid))
         quantifiers_cont_local = stability_quantifiers_along_continuation(
-            dynamics, attractors_cont_local, pcurve_local, ics_from_grid(grid), ε = 0.1, finite_time = 0.5,
+            dynamics, attractors_cont_local, pcurve_local, gcsampler; ε = 0.1, finite_time = 0.5,
             proximity_mapper_options = proximity_mapper_options_local
         )
 
@@ -415,7 +416,7 @@ end
         Dict(2 => StateSpaceSet([SVector(1.0, 1.0)]), 1 => StateSpaceSet([SVector(-1.0, -1.0)])),
     ]
     quantifiers_cont = stability_quantifiers_along_continuation(
-        dynamics, attractors_cont, pcurve, A;
+        dynamics, attractors_cont, pcurve, PrescribedICs(A);
         ε = 0.1,
         n_basin_entropy = 2,
         show_progress = false,

--- a/test/nonlocal/stability_quantifiers_accumulator.jl
+++ b/test/nonlocal/stability_quantifiers_accumulator.jl
@@ -4,7 +4,7 @@ using Test, Attractors
 using Random
 
 @testset "dumb map analytic" begin
-    function dumb_map(z, p, n)
+    function dumb_map2(z, p, n)
         x, y = z
         r = p[1]
         if r < 0.5
@@ -19,7 +19,7 @@ using Random
     end
     # Test the computation of nonlocal stability quantifiers using the
     # `StabilityQuantifiersAccumulator` for a dumb map.
-    dynamics = DiscreteDynamicalSystem(dumb_map, [1.0, 1.0], [1.0])
+    dynamics = DeterministicIteratedMap(dumb_map2, [1.0, 1.0], [1.0])
     grid = ([-1, 0, 1.0], [-1, 0, 1.0])
     bmap = BasinMapRecurrences(dynamics, grid; sparse = false)
     A = ics_from_grid(grid)
@@ -176,6 +176,16 @@ using Random
         @test quantifiers_agg["minimal_critical_shock_magnitude"][1][merged_id_1] == Inf
         @test quantifiers_agg["minimal_critical_shock_magnitude"][2][merged_id_2] == Inf
     end
+
+    @testset "continuation with ASCM" begin
+        accumulator = StabilityQuantifiersAccumulator(bmap)
+        pcurve = [[1 => p] for p in [-1.0, 1.0]]
+        ascm = AttractorSeedContinueMatch(accumulator)
+        gco = global_continuation(ascm, pcurve, PrescribedICs(A))
+        @test !isempty(gco.quantifiers)
+        @test haskey(gco.quantifiers, "mean_convergence_pace")
+    end
+
 end
 
 
@@ -291,7 +301,7 @@ end
 
 @testset "user-defined quantifiers" begin
 
-    function dumb_map(z, p, n)
+    function dumb_map2(z, p, n)
         x, y = z
         r = p[1]
         if r < 0.5
@@ -307,7 +317,7 @@ end
 
     r = 0.5
     grid = ([-1, 0, 1], [-1, 0, 1])
-    dynamics = DiscreteDynamicalSystem(dumb_map, [1.0, 1.0], [r])
+    dynamics = DiscreteDynamicalSystem(dumb_map2, [1.0, 1.0], [r])
     bmap = BasinMapRecurrences(dynamics, grid; sparse = false)
     A = ics_from_grid(grid)
 
@@ -353,7 +363,7 @@ end
 end
 
 @testset "sampled basin entropy quantifiers" begin
-    function dumb_map(z, p, n)
+    function dumb_map2(z, p, n)
         x, y = z
         r = p[1]
         if r < 0.5
@@ -369,7 +379,7 @@ end
 
     r = 1.0
     grid = ([-1, 0, 1], [-1, 0, 1])
-    dynamics = DiscreteDynamicalSystem(dumb_map, [1.0, 1.0], [r])
+    dynamics = DiscreteDynamicalSystem(dumb_map2, [1.0, 1.0], [r])
     bmap = BasinMapRecurrences(dynamics, grid; sparse = false)
     A = ics_from_grid(grid)
 
@@ -417,7 +427,7 @@ end
 
 
 @testset "accumulator with featurizer" begin
-    function dumb_map(z, p, n)
+    function dumb_map2(z, p, n)
         x, y = z
         r = p[1]
         if r < 0.5
@@ -431,7 +441,7 @@ end
         end
     end
     rs = [0.5, 1.0]
-    dynamics = DiscreteDynamicalSystem(dumb_map, [1.0, 1.0], [1.0])
+    dynamics = DiscreteDynamicalSystem(dumb_map2, [1.0, 1.0], [1.0])
     grid = ([-1, 0, 1], [-1, 0, 1])
     ics = ics_from_grid(grid)
     featurizer(A, t) = A[end]

--- a/test/nonlocal/stability_quantifiers_accumulator.jl
+++ b/test/nonlocal/stability_quantifiers_accumulator.jl
@@ -357,7 +357,9 @@ end
     @testset "continuation" begin
         rs = [0.5, 1.0]
         gca = AttractorSeedContinueMatch(accumulator)
-        quantifiers_cont, attractors_cont = global_continuation(gca, rs, 1, A)
+        pcurve = [Dict(1 => r) for r in rs]
+        gco = global_continuation(gca, pcurve, PrescribedICs(A))
+        quantifiers_cont = gco.quantifiers
         @test quantifiers_cont["extra"] == [Dict(1 => 0, 2 => 3), Dict(1 => 0, 2 => 0)]
     end
 end
@@ -450,7 +452,7 @@ end
     accumulator = StabilityQuantifiersAccumulator(bmap)
 
     @testset "single parameter" begin
-        fs, labels = basins_fractions(accumulator, ics)
+        fs, labels = basins_fractions_labels(accumulator, ics)
         @test all(sort!(collect(values(fs))) .≈ [0.333333333333333333, 0.6666666666666])
         quantifiers = finalize_accumulator(accumulator)
         @test isequal(quantifiers["minimal_critical_shock_magnitude"], Dict(2 => 2.0, 1 => 1.0))
@@ -459,8 +461,8 @@ end
     @testset "continuation" begin
         pcurve = [[1 => r] for r in rs]
         acsm = AttractorSeedContinueMatch(accumulator)
-        quantifiers_cont, attractors_cont = global_continuation(acsm, pcurve, ics)
-
+        gco = global_continuation(acsm, pcurve, PrescribedICs(ics))
+        quantifiers_cont = gco.quantifiers
         @test isequal(quantifiers_cont["minimal_critical_shock_magnitude"][2], Dict(2 => 2.0, 1 => 1.0))
         fs = quantifiers_cont["basin_fraction"][1]
         @test all(sort!(collect(v for (k, v) in fs if k != -1)) .≈ [0.333333333333333333, 0.6666666666666])


### PR DESCRIPTION
This is hopefully the last change before we can release v2. This is a breaking change and changes the output of `global_continuation`. The reason was that at the moment the same function had different output depending on if it was used with the accumulator or not. This was a bit messy. In addition, there was no way to add more information from the continuation to the output, that may be desired to do in the future as we add more functionality.

So this PR fixes all of that by enforcing the output of global cont to be a special type that has fields that can be extended with more information in the future. The same type is returned regardless of what continuation is being done, which adds coherence to the whole library.