### PR TITLE
copy attr dict in basin types

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Attractors"
 uuid = "f3fd9213-ca85-4dba-9dfd-7fc91308fec7"
 authors = ["George Datseris <datseris.george@gmail.com>", "Kalel Rossi", "Alexandre Wagemakers"]
 repo = "https://github.com/JuliaDynamics/Attractors.jl.git"
-version = "2.0.5"
+version = "2.0.6"
 
 [deps]
 BijectiveHilbert = "91e7fc40-53cd-4118-bd19-d7fcd1de2a54"

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Attractors"
 uuid = "f3fd9213-ca85-4dba-9dfd-7fc91308fec7"
 authors = ["George Datseris <datseris.george@gmail.com>", "Kalel Rossi", "Alexandre Wagemakers"]
 repo = "https://github.com/JuliaDynamics/Attractors.jl.git"
-version = "2.0.4"
+version = "2.0.5"
 
 [deps]
 BijectiveHilbert = "91e7fc40-53cd-4118-bd19-d7fcd1de2a54"

--- a/docs/src/api_vis.md
+++ b/docs/src/api_vis.md
@@ -19,7 +19,7 @@ Common keywords for plotting functions in Attractors.jl are:
 - `access = [1, 2]`: indices of which dimensions of an attractor to select and visualize in a two-dimensional plot (as in [`animate_attractors_continuation`](@ref)).
 - `colors`: a dictionary mapping basin ids (i.e., including the `-1` key) to a color. By default the JuliaDynamics colorscheme is used if less than 7 ids are present, otherwise random colors from the `:darktest` colormap.
 - `markers`: dictionary mapping attractor ids to markers they should be plotted as
-- `labels = Dict(ukeys .=> ukeys)`: how to label each attractor.
+- `labels = Dict(ukeys .=> string.(ukeys))`: how to label each attractor. The values need to be valid inputs to Makie's `label` keyword. The value `nothing` can be used for a particular label to be hidden.
 - `add_legend = length(ukeys) < 7`: whether to add a legend mapping colors to labels.
 - `axislegend_kwargs = (position = :lt,)`: propagated to `axislegend` if a legend is added
 

--- a/ext/plotting.jl
+++ b/ext/plotting.jl
@@ -48,7 +48,7 @@ function Attractors.plot_attractors!(
         ukeys = sort(collect(keys(attractors))), # internal argument just for other keywords
         colors = colors_from_keys(ukeys),
         markers = markers_from_keys(ukeys),
-        labels = Dict(ukeys .=> ukeys),
+        labels = Dict(ukeys .=> string.(ukeys)),
         add_legend = length(ukeys) < 7,
         axislegend_kwargs = NamedTuple(),
         access = SVector(1, 2),
@@ -61,7 +61,7 @@ function Attractors.plot_attractors!(
             ax, A[:, access];
             color = (colors[k], 0.9), markersize = 20,
             marker = markers[k],
-            label = "$(labels[k])",
+            label = labels[k],
             sckwargs...
         )
     end
@@ -96,7 +96,7 @@ function Attractors.heatmap_basins_attractors!(
         ukeys = unique(basins), # internal argument just for other keywords
         colors = colors_from_keys(ukeys),
         markers = markers_from_keys(ukeys),
-        labels = Dict(ukeys .=> ukeys),
+        labels = Dict(ukeys .=> string.(ukeys)),
         add_legend = length(ukeys) < 7,
         access = SVector(1, 2),
         sckwargs = (strokewidth = 1.5, strokecolor = :white)
@@ -170,7 +170,7 @@ function Attractors.shaded_basins_heatmap!(
 
     cmap, colors = custom_colormap_shaded(ukeys)
     markers = markers_from_keys(ukeys)
-    labels = Dict(ukeys .=> ukeys)
+    labels = Dict(ukeys .=> string.(ukeys))
     add_legend = length(ukeys) < 7
 
     it = findall(iterations .> maxit)
@@ -203,7 +203,7 @@ function Attractors.shaded_basins_heatmap!(
                 color = colors[k], markersize = 20,
                 marker = markers[k],
                 strokewidth = 1.5, strokecolor = :white,
-                label = "$(labels[k])"
+                label = labels[k]
             )
         end
         # Add legend using colors only
@@ -267,7 +267,7 @@ function Attractors.plot_basins_curves!(
         ax, fractions_cont, prange = 1:length(fractions_cont);
         ukeys = unique_keys(fractions_cont), # internal argument
         colors = colors_from_keys(ukeys),
-        labels = Dict(ukeys .=> ukeys),
+        labels = Dict(ukeys .=> string.(ukeys)),
         separatorwidth = 1, separatorcolor = "white",
         add_legend = length(ukeys) < 7,
         axislegend_kwargs = (position = :lt,),
@@ -294,7 +294,7 @@ function Attractors.plot_basins_curves!(
             end
             band!(
                 ax, prange, l, u;
-                color = colors[k], label = "$(labels[k])", series_kwargs...
+                color = colors[k], label = labels[k], series_kwargs...
             )
             if separatorwidth > 0 && j < length(ukeys)
                 lines!(ax, prange, u; color = separatorcolor, linewidth = separatorwidth, linestyle = :solid)
@@ -305,7 +305,7 @@ function Attractors.plot_basins_curves!(
         for k in ukeys
             scatterlines!(
                 ax, prange, bands[k];
-                color = colors[k], label = "$(labels[k])", marker = markers[k],
+                color = colors[k], label = labels[k], marker = markers[k],
                 markersize = 10, linewidth = 3, series_kwargs...
             )
         end
@@ -342,7 +342,7 @@ function Attractors.plot_continuation_curves!(
         ax, continuation_info, prange = 1:length(continuation_info);
         ukeys = unique_keys(continuation_info), # internal argument
         colors = colors_from_keys(ukeys),
-        labels = Dict(ukeys .=> ukeys),
+        labels = Dict(ukeys .=> string.(ukeys)),
         add_legend = length(ukeys) < 7,
         markers = markers_from_keys(ukeys),
         series_kwargs = NamedTuple(),
@@ -357,7 +357,7 @@ function Attractors.plot_continuation_curves!(
     for k in ukeys
         scatterlines!(
             ax, prange, series[k];
-            color = colors[k], label = "$(labels[k])", marker = markers[k],
+            color = colors[k], label = labels[k], marker = markers[k],
             markersize = 10, linewidth = 3, series_kwargs...
         )
     end
@@ -387,7 +387,7 @@ function Attractors.plot_basins_attractors_curves(
         a2rs::Vector, prange = 1:length(attractors_cont);
         ukeys = unique_keys(fractions_cont), # internal argument
         colors = colors_from_keys(ukeys),
-        labels = Dict(ukeys .=> ukeys),
+        labels = Dict(ukeys .=> string.(ukeys)),
         markers = markers_from_keys(ukeys),
         style = :band,
         kwargs...
@@ -424,7 +424,7 @@ function Attractors.plot_basins_attractors_curves!(
         attractor_to_real, prange = 1:length(attractors_cont);
         ukeys = unique_keys(fractions_cont), # internal argument
         colors = colors_from_keys(ukeys),
-        labels = Dict(ukeys .=> ukeys),
+        labels = Dict(ukeys .=> string.(ukeys)),
         kwargs...
     )
 

--- a/src/mapping/basins_types.jl
+++ b/src/mapping/basins_types.jl
@@ -44,7 +44,7 @@ A subtype of [`BasinsOfAttraction`](@ref) whose `basins` of attraction are repre
 the state space domain that `basins` cover, and must be a tuple of ranges or ordered vectors.
 Each vector is a dimension for each axis of the `basins` array.
 Alternative, `grid` can be a `RegularGrid` or `IrregularGrid`.
-The `attractors` are a dictionary mapping labels to `StateSpaceSet`s.
+The `attractors` are a dictionary mapping labels to `StateSpaceSet`s that is copied in.
 """
 struct ArrayBasinsOfAttraction{ID, D, B <: AbstractArray{ID, D}, G <: Grid, K, S <: StateSpaceSet} <: BasinsOfAttraction{ID}
     basins::B
@@ -59,7 +59,7 @@ struct ArrayBasinsOfAttraction{ID, D, B <: AbstractArray{ID, D}, G <: Grid, K, S
             length(grid.grid) != dimension(first(values(attractors))) && error("The attractor points and the grid must have the same number of dimensions")
         end
         B = typeof(basins)
-        return new{ID, D, B, G, K, S}(basins, attractors, grid)
+        return new{ID, D, B, G, K, S}(basins, copy(attractors), grid)
     end
 end
 # ArrayBasinsOfAttraction with grid as tuple
@@ -80,7 +80,7 @@ end
 
 A subtype of [`BasinsOfAttraction`](@ref) where the basins are sampled points in the state space.
 `basins` are thus a `vector::AbstractVector`, each entry corresponding to the point in `sampled_points`.
-The `attractors` are the usual form of Attractors.jl, a dictionary labels to `StateSpaceSet`s.
+The `attractors` are a dictionary mapping labels to `StateSpaceSet`s that is copied in.
 
 `sampled_points` can be a `StateSpaceSet` with the same dimensionality and element type
 as the attractors, or alternatively a vector of points with the same requirements.
@@ -102,7 +102,7 @@ struct SampledBasinsOfAttraction{ID, D, T, AK, S <: StateSpaceSet{D, T}, ss} <: 
         {ID, D, T, AK, S <: StateSpaceSet{D, T}}
         length(basins) != length(sampled_points) && error("The basins and the sampled points must have equal length")
         search_struct = searchstructure(tree, sampled_points, metric; ss_kwargs...)
-        return new{ID, D, T, AK, S, typeof(search_struct)}(basins, attractors, sampled_points, search_struct)
+        return new{ID, D, T, AK, S, typeof(search_struct)}(basins, copy(attractors), sampled_points, search_struct)
     end
 end
 


### PR DESCRIPTION
There was some unexpected behaviour: if you estimated a `BoA` type, and then later did a global continuation, the attractors in the `BoA` type would change and become the continuation's last attractors. This is because Dictionaries are mutable containers and both the BoA type and the continuation were using the same container.

Now the attractor dict is copied into the BoA type to ensure it stays immutable as would be expected.